### PR TITLE
Document usage from other languages

### DIFF
--- a/demo-annotations.md
+++ b/demo-annotations.md
@@ -1,0 +1,293 @@
+# Demo Annotations
+
+## Important
+
+If you're not looking to understand the internal of Appdash, you're probably in the wrong place.
+
+This document gives a large-scale overview of the collections that occur (i.e. would be sent to a remote Go/Appdash collection server) when running the `cmd/appdash demo` demo and navigating to `http://localhost:8699/api-calls` in Google Chrome.
+
+## Span Format
+
+Remember that the span format is `trace-id/span-id/parent-id`, so for example `8d4bdb285382e850/3be70fd9713c47cf/d9564f71aae8aba2` -- `8d4` is the trace/root ID, `3be` is the span's ID, and `d95` is the parent span's ID.
+
+### Collection 1
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/3be70fd9713c47cf/d9564f71aae8aba2"
+    len(anns) = 2
+
+Annotation(key="Name", value="localhost:8699")
+Annotation(key="_schema:name", value="")
+```
+
+### Collection 2
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/3be70fd9713c47cf/d9564f71aae8aba2"
+    len(anns) = 2
+
+Annotation(key="Name", value="/endpoint-A")
+Annotation(key="_schema:name", value="")
+```
+
+### Collection 3
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/3be70fd9713c47cf/d9564f71aae8aba2"
+    len(anns) = 17
+
+Annotation(key="ServerRecv", value="2015-02-21T17:02:28.739872792-07:00")
+Annotation(key="ServerSend", value="2015-02-21T17:02:28.990097629-07:00")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/endpoint-A")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.User-Agent", value="Go 1.1 package http")
+Annotation(key="Request.Headers.Span-Id", value="8d4bdb285382e850/3be70fd9713c47cf/d9564f71aae8aba2")
+Annotation(key="Request.Headers.Accept-Encoding", value="gzip")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="127.0.0.1:35786")
+Annotation(key="Response.Headers.Span-Id", value="8d4bdb285382e850/3be70fd9713c47cf/d9564f71aae8aba2")
+Annotation(key="Response.ContentLength", value="23")
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="Route", value="/endpoint-A")
+Annotation(key="User", value="")
+Annotation(key="_schema:HTTPServer", value="")
+```
+
+### Collection 4
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/3be70fd9713c47cf/d9564f71aae8aba2"
+    len(anns) = 15
+
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="Response.Headers.Date", value="Sun, 22 Feb 2015 00:02:28 GMT")
+Annotation(key="Response.Headers.Content-Length", value="23")
+Annotation(key="Response.Headers.Content-Type", value="text/plain; charset=utf-8")
+Annotation(key="Response.ContentLength", value="23")
+Annotation(key="ClientSend", value="2015-02-21T17:02:28.738020881-07:00")
+Annotation(key="ClientRecv", value="2015-02-21T17:02:28.990831661-07:00")
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/endpoint-A")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.Span-Id", value="8d4bdb285382e850/3be70fd9713c47cf/d9564f71aae8aba2")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="_schema:HTTPClient", value="")
+```
+
+### Collection 5
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/ef1ba6f3fa12d5d2/d9564f71aae8aba2"
+    len(anns) = 2
+
+Annotation(key="Name", value="localhost:8699")
+Annotation(key="_schema:name", value="")
+```
+
+### Collection 6
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/ef1ba6f3fa12d5d2/d9564f71aae8aba2"
+    len(anns) = 2
+
+Annotation(key="Name", value="/endpoint-B")
+Annotation(key="_schema:name", value="")
+```
+
+### Collection 7
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/ef1ba6f3fa12d5d2/d9564f71aae8aba2"
+    len(anns) = 17
+
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="Response.Headers.Span-Id", value="8d4bdb285382e850/ef1ba6f3fa12d5d2/d9564f71aae8aba2")
+Annotation(key="Response.ContentLength", value="28")
+Annotation(key="Route", value="/endpoint-B")
+Annotation(key="User", value="")
+Annotation(key="ServerRecv", value="2015-02-21T17:02:28.991944372-07:00")
+Annotation(key="ServerSend", value="2015-02-21T17:02:29.067157987-07:00")
+Annotation(key="Request.URI", value="/endpoint-B")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.Span-Id", value="8d4bdb285382e850/ef1ba6f3fa12d5d2/d9564f71aae8aba2")
+Annotation(key="Request.Headers.Accept-Encoding", value="gzip")
+Annotation(key="Request.Headers.User-Agent", value="Go 1.1 package http")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="127.0.0.1:35787")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Request.Method", value="GET")
+Annotation(key="_schema:HTTPServer", value="")
+```
+
+### Collection 8
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/ef1ba6f3fa12d5d2/d9564f71aae8aba2"
+    len(anns) = 15
+
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/endpoint-B")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.Span-Id", value="8d4bdb285382e850/ef1ba6f3fa12d5d2/d9564f71aae8aba2")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="Response.Headers.Date", value="Sun, 22 Feb 2015 00:02:29 GMT")
+Annotation(key="Response.Headers.Content-Length", value="28")
+Annotation(key="Response.Headers.Content-Type", value="text/plain; charset=utf-8")
+Annotation(key="Response.ContentLength", value="28")
+Annotation(key="ClientSend", value="2015-02-21T17:02:28.991155375-07:00")
+Annotation(key="ClientRecv", value="2015-02-21T17:02:29.067694228-07:00")
+Annotation(key="_schema:HTTPClient", value="")
+```
+
+### Collection 9
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/910810f4ade66b9d/d9564f71aae8aba2"
+    len(anns) = 2
+
+Annotation(key="Name", value="localhost:8699")
+Annotation(key="_schema:name", value="")
+```
+
+### Collection 10
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/910810f4ade66b9d/d9564f71aae8aba2"
+    len(anns) = 2
+
+Annotation(key="Name", value="/endpoint-C")
+Annotation(key="_schema:name", value="")
+```
+
+### Collection 11
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/910810f4ade66b9d/d9564f71aae8aba2"
+    len(anns) = 17
+
+Annotation(key="ServerRecv", value="2015-02-21T17:02:29.068944038-07:00")
+Annotation(key="ServerSend", value="2015-02-21T17:02:29.369228802-07:00")
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/endpoint-C")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.User-Agent", value="Go 1.1 package http")
+Annotation(key="Request.Headers.Span-Id", value="8d4bdb285382e850/910810f4ade66b9d/d9564f71aae8aba2")
+Annotation(key="Request.Headers.Accept-Encoding", value="gzip")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="127.0.0.1:35788")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Response.Headers.Span-Id", value="8d4bdb285382e850/910810f4ade66b9d/d9564f71aae8aba2")
+Annotation(key="Response.ContentLength", value="32")
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="Route", value="/endpoint-C")
+Annotation(key="User", value="")
+Annotation(key="_schema:HTTPServer", value="")
+```
+
+### Collection 12
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/910810f4ade66b9d/d9564f71aae8aba2"
+    len(anns) = 15
+
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.Span-Id", value="8d4bdb285382e850/910810f4ade66b9d/d9564f71aae8aba2")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/endpoint-C")
+Annotation(key="Response.Headers.Content-Length", value="32")
+Annotation(key="Response.Headers.Content-Type", value="text/plain; charset=utf-8")
+Annotation(key="Response.Headers.Date", value="Sun, 22 Feb 2015 00:02:29 GMT")
+Annotation(key="Response.ContentLength", value="32")
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="ClientSend", value="2015-02-21T17:02:29.068068228-07:00")
+Annotation(key="ClientRecv", value="2015-02-21T17:02:29.370099164-07:00")
+Annotation(key="_schema:HTTPClient", value="")
+```
+
+### Collection 13
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/d9564f71aae8aba2"
+    len(anns) = 2
+
+Annotation(key="Name", value="/api-calls")
+Annotation(key="_schema:name", value="")
+```
+
+### Collection 14
+```
+RemoteCollector.Collect called
+    span = "8d4bdb285382e850/d9564f71aae8aba2"
+    len(anns) = 21
+
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/api-calls")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.Cookie", value="_ga=GA1.1.1121926742.1421522090")
+Annotation(key="Request.Headers.Connection", value="keep-alive")
+Annotation(key="Request.Headers.Cache-Control", value="max-age=0")
+Annotation(key="Request.Headers.Accept", value="text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
+Annotation(key="Request.Headers.User-Agent", value="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36")
+Annotation(key="Request.Headers.Accept-Encoding", value="gzip, deflate, sdch")
+Annotation(key="Request.Headers.Accept-Language", value="en-US,en;q=0.8")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="127.0.0.1:35783")
+Annotation(key="Response.Headers.Span-Id", value="8d4bdb285382e850/d9564f71aae8aba2")
+Annotation(key="Response.ContentLength", value="226")
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="Route", value="/api-calls")
+Annotation(key="User", value="")
+Annotation(key="ServerRecv", value="2015-02-21T17:02:28.737546589-07:00")
+Annotation(key="ServerSend", value="2015-02-21T17:02:29.37244206-07:00")
+Annotation(key="_schema:HTTPServer", value="")
+```
+
+### Collection 15
+```
+RemoteCollector.Collect called
+    span = "0b5d081c1b09fac1/08b40a40832a70be"
+    len(anns) = 2
+
+Annotation(key="Name", value="/favicon.ico")
+Annotation(key="_schema:name", value="")
+```
+
+### Collection 16
+```
+RemoteCollector.Collect called
+    span = "0b5d081c1b09fac1/08b40a40832a70be"
+    len(anns) = 20
+
+Annotation(key="ServerSend", value="2015-02-21T17:02:29.996661592-07:00")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.Accept-Language", value="en-US,en;q=0.8")
+Annotation(key="Request.Headers.Cookie", value="_ga=GA1.1.1121926742.1421522090")
+Annotation(key="Request.Headers.Connection", value="keep-alive")
+Annotation(key="Request.Headers.Accept", value="*/*")
+Annotation(key="Request.Headers.User-Agent", value="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36")
+Annotation(key="Request.Headers.Accept-Encoding", value="gzip, deflate, sdch")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="127.0.0.1:35783")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/favicon.ico")
+Annotation(key="Response.ContentLength", value="132")
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="Response.Headers.Span-Id", value="0b5d081c1b09fac1/08b40a40832a70be")
+Annotation(key="Route", value="/favicon.ico")
+Annotation(key="User", value="")
+Annotation(key="ServerRecv", value="2015-02-21T17:02:29.996609002-07:00")
+Annotation(key="_schema:HTTPServer", value="")
+```
+

--- a/other-languages.md
+++ b/other-languages.md
@@ -1,0 +1,187 @@
+# Appdash in other languages
+
+It is possible to have other programming languages communicate with a Go-based Appdash collection server (e.g. `cmd/appdash serve`).
+
+This enables other applications, not written in Go, to communicate performance, debug information, and logs to a Appdash collection server.
+
+Currently only a Python client is available, see the `python/` sub-directory for more information. The rest of this document will describe the details of how using Appdash from other languages would be achieved.
+
+# Wire Protocol
+
+Appdash collection servers communicate with clients via Google's protobuf (varint delimited) messages.
+
+1. A varint is sent over the wire to communicate _how large the protobuf message is_. This is done because protobuf doesn't actually handle _streams of messages_, rather just the encoding/decoding of _single messages_.
+2. The actual protobuf-encoded message is sent.
+
+The actual protobuf file (which can be used to generate code for most languages) can be found in the `internal/wire/collector.proto` file.
+
+We will now discuss in-depth the protobuf format, and how everything works.
+
+# CollectPacket
+
+A CollectPacket is the high-level message structure. It is sent from a Appdash client to a remote Appdash collection server (e.g. `cmd/appdash serve`). It is composed of a single _SpanID_ and any number of _Annotations_ associated with the identified span. For example, a _CollectPacket_ would be sent to the server to say what a span's name was, how long it took, etc.
+
+When the server receives a CollectPacket, it stores the annotations associated with the span for later (in _a Store_). These annotations are unmarshaled into _Events_ which are then displayed nicely inside Appdash's web UI, which lets you analyse the trace, etc.
+
+# SpanID
+
+The SpanID portion of the protobuf file looks like:
+
+```
+// SpanID is the group of information which can uniquely identify the exact
+// span being collected.
+required group SpanID = 1 {
+	// trace is the root ID of the tree that contains all of the spans
+	// related to this one.
+	required fixed64 trace = 2;
+
+	// span is an ID that probabilistically uniquely identifies this span.
+	required fixed64 span = 3;
+
+	// parent is the ID of the parent span, if any.
+	optional fixed64 parent = 4;
+}
+```
+
+A SpanID is made up of three ID's in total:
+
+1. The _trace ID_ (also called the _root ID_).
+2. The _span ID_.
+3. The _parent ID_, or zero.
+
+Each ID is an unsigned 64-bit integer which has no special quality other than _uniquely identifying that span_. They are random numbers and are chosen purely to avoid collision with one another.
+
+All spans in a trace share the same _trace ID_, and each span is a distant child of a parent span or the _root span (aka. trace)_.
+
+# Annotation
+
+The Annotation portion of the protobuf file looks like:
+
+```
+// Annotation is any number of annotations for the span to be collected.
+repeated group Annotation = 5 {
+	// key is the annotation's key.
+	required string key = 6;
+
+	// value is the annotation's value, which may be either human or
+	// machine readable, depending on the schema of the event that
+	// generated it.
+	optional bytes value = 7;
+}
+```
+
+As it looks, a annotation is a very arbitrary value which _puts meaning (or "annotates")_ a specific span. It has a key and a value that is either human or machine readable. You can define your own annotations as you see fit, but for most purposes you will utilize the ones exposed by apptrace by default.
+
+Make explicit note that although annotations _may be_ ordered by specific clients -- there is no such requirement. Any robust client or server should appropriately _handle annotations as a list_ and _expect no specific order_ of them.
+
+# Events
+
+Events (things like associating a name, message, log event, SQL event, or HTTP event) are _marshaled_ into a set of multiple _annotations_. These annotations are then sent over the wire in the form of a CollectPacket, described above.
+
+What follows is a description of the events which Appdash recognizes and renders neatly in the UI, and exactly how they are marshaled into annotations.
+
+Note that the code is psuedo code, not actual code.
+
+## SpanNameEvent
+
+A SpanNameEvent sets the name of a span. It is marshaled into two span annotations:
+
+```
+Annotation(key="Name", value="theNameOfTheSpan")
+Annotation(key="_schema:name", value="")
+```
+
+## MsgEvent
+
+A MsgEvent represents a message event, with human readable text. Most clients
+will emit a LogEvent instead, which also contains a timestamp.
+
+```
+Annotation(key="Msg", value="hello")
+Annotation(key="_schema:msg", value="")
+```
+
+## LogEvent
+
+A LogEvent represents a log message event, with human readable text and a timestamp.
+
+```
+Annotation(key="Msg", value="hello")
+Annotation(key="Time", value="2015-02-19T19:31:17.451675861-07:00")
+Annotation(key="_schema:log", value="")
+```
+
+## SQLEvent
+
+A SQLEvent represents a SQL query event. It is marshaled into several annotations:
+
+```
+Annotation(key="Tag", value="fakeTag0")
+Annotation(key="ClientSend", value="2015-02-19T19:31:17.449917809-07:00")
+Annotation(key="ClientRecv", value="2015-02-19T19:31:18.442917809-07:00")
+Annotation(key="SQL", value="SELECT * FROM table_name;")
+Annotation(key="_schema:SQL", value="")
+```
+
+## HTTPServerEvent
+
+A HTTPServerEvent represents an HTTP server serving a single client. It includes several annotations with information about the request, it's headers, etc.
+
+Typically it will be preceded by a SpanNameEvent with the HTTP path requested, for example:
+
+```
+Annotation(key="Name", value="localhost:8699")
+Annotation(key="_schema:name", value="")
+```
+
+Information about the request is placed into `Request.Foo` keys, information about the response is placed into `Response.Foo` keys, etc. A server handling a request to `/endpoint-A` would for instance generate annotations like:
+
+```
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/endpoint-A")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.Accept-Encoding", value="gzip")
+Annotation(key="Request.Headers.User-Agent", value="Go 1.1 package http")
+Annotation(key="Request.Headers.Span-Id", value="3b83e3e091f8946a/76dc6cbdb3863717/a4475c5cc57a69d4")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="127.0.0.1:35741")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="Response.Headers.Span-Id", value="3b83e3e091f8946a/76dc6cbdb3863717/a4475c5cc57a69d4")
+Annotation(key="Response.ContentLength", value="23")
+Annotation(key="Route", value="/endpoint-A")
+Annotation(key="User", value="")
+Annotation(key="ServerRecv", value="2015-02-21T16:36:13.248971779-07:00")
+Annotation(key="ServerSend", value="2015-02-21T16:36:13.499282101-07:00")
+Annotation(key="_schema:HTTPServer", value="")
+```
+
+TODO: describe `Request.Headers.Span-Id`.
+
+## HTTPClientEvent
+
+A HTTPClientEvent represents a HTTP client making an outbound request. Very similiar to HTTPServerEvent, it includes several annotations with information about the request, it's headers, etc.
+
+For example, a outbound request to `/endpoint-A`:
+
+```
+Annotation(key="ClientSend", value="2015-02-21T16:36:13.113231752-07:00")
+Annotation(key="ClientRecv", value="2015-02-21T16:36:13.500518641-07:00")
+Annotation(key="Request.Host", value="localhost:8699")
+Annotation(key="Request.RemoteAddr", value="")
+Annotation(key="Request.ContentLength", value="0")
+Annotation(key="Request.Method", value="GET")
+Annotation(key="Request.URI", value="/endpoint-A")
+Annotation(key="Request.Proto", value="HTTP/1.1")
+Annotation(key="Request.Headers.Span-Id", value="3b83e3e091f8946a/76dc6cbdb3863717/a4475c5cc57a69d4")
+Annotation(key="Response.Headers.Content-Type", value="text/plain; charset=utf-8")
+Annotation(key="Response.Headers.Date", value="Sat, 21 Feb 2015 23:36:13 GMT")
+Annotation(key="Response.Headers.Content-Length", value="23")
+Annotation(key="Response.ContentLength", value="23")
+Annotation(key="Response.StatusCode", value="200")
+Annotation(key="_schema:HTTPClient", value="")
+```
+
+## Larger-Scale Example
+
+A larger-scale example of the annotations generated via running `cmd/appdash demo` is available. See the `demo-annotations.md` file for more information.


### PR DESCRIPTION
This change adds two new Markdown files serving as general documentation of Appdash from other languages. These are lower-level details of how Appdash functions under the hood that I personally found useful during development of the `python/appdash` support library (see #36).

Helps #31 