### PR TITLE
Add optional ImportantEvent interface.

### DIFF
--- a/event.go
+++ b/event.go
@@ -11,6 +11,13 @@ type Event interface {
 	Schema() string
 }
 
+// ImportantEvent is an event that can describe in particular which annotation
+// keys it finds important. Only important annotation keys are displayed in the
+// web UI by default.
+type ImportantEvent interface {
+	Important() []string
+}
+
 // EventMarshaler is the interface implemented by an event that can
 // marshal a representation of itself into annotations.
 //

--- a/httptrace/client.go
+++ b/httptrace/client.go
@@ -58,6 +58,15 @@ type ClientEvent struct {
 // Schema returns the constant "HTTPClient".
 func (ClientEvent) Schema() string { return "HTTPClient" }
 
+// Important implements the appdash ImportantEvent.
+func (ClientEvent) Important() []string {
+	return []string{
+		"Request.Headers.If-Modified-Since",
+		"Request.Headers.If-None-Match",
+		"Response.StatusCode",
+	}
+}
+
 func (e ClientEvent) Start() time.Time { return e.ClientSend }
 func (e ClientEvent) End() time.Time   { return e.ClientRecv }
 

--- a/httptrace/server.go
+++ b/httptrace/server.go
@@ -51,6 +51,11 @@ type ServerEvent struct {
 // Schema returns the constant "HTTPServer".
 func (ServerEvent) Schema() string { return "HTTPServer" }
 
+// Important implements the appdash ImportantEvent.
+func (ServerEvent) Important() []string {
+	return []string{"Response.StatusCode"}
+}
+
 func (e ServerEvent) Start() time.Time { return e.ServerRecv }
 func (e ServerEvent) End() time.Time   { return e.ServerSend }
 

--- a/span.go
+++ b/span.go
@@ -176,6 +176,23 @@ type Annotation struct {
 	Value []byte
 }
 
+// Important determines if this annotation's key is considered important to any
+// of the registered event types.
+func (a Annotation) Important() bool {
+	for _, ev := range registeredEvents {
+		i, ok := ev.(ImportantEvent)
+		if !ok {
+			continue
+		}
+		for _, k := range i.Important() {
+			if a.Key == k {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // String returns a formatted list of annotations.
 func (as Annotations) String() string {
 	var buf bytes.Buffer

--- a/sqltrace/sql.go
+++ b/sqltrace/sql.go
@@ -20,6 +20,10 @@ type SQLEvent struct {
 // constant schema string, "SQL".
 func (SQLEvent) Schema() string { return "SQL" }
 
+// Important implements the appdash ImportantEvent by returning the SQL and Tag
+// keys.
+func (SQLEvent) Important() []string { return []string{"SQL", "Tag"} }
+
 // Start implements the appdash TimespanEvent interface by returning the time
 // at which the SQL query was sent out.
 func (e SQLEvent) Start() time.Time { return e.ClientSend }

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -360,7 +360,7 @@
    padding-top: 1em;
    padding-bottom: 1em;
  }
- #profileView {
+ #profileView, #verboseDataView {
    display: none;
  }
 </style>
@@ -369,6 +369,9 @@
 <div class="viewMode btn-group btn-group-justified btn-group-xs" data-toggle="buttons" id="radioopt">
   <label class="btn btn-primary active">
     <input type="radio" name="view" id="btnDataView" value="Data View">Data View</input>
+  </label>
+  <label class="btn btn-primary">
+    <input type="radio" name="view" id="btnVerboseDataView" value="Verbose Data View">Verbose Data View</input>
   </label>
   <label class="btn btn-primary">
     <input type="radio" name="view" id="btnProfileView" value="Profile View">Profile View</input>
@@ -388,6 +391,12 @@
        $("#dataView").hide();
      }
 
+     if(id == "btnVerboseDataView") {
+       $("#verboseDataView").show();
+     } else {
+       $("#verboseDataView").hide();
+     }
+
      if(id == "btnProfileView") {
        $("#profileView").show();
      } else {
@@ -396,7 +405,7 @@
   });
 </script>
 
-<!-- The data view layout -->
+<!-- The important data view layout -->
 <ul id="dataView" class="traces">
   <li class="trace" id="span-{{.Trace.Span.ID.Span}}">
     {{if .Trace.Name}}
@@ -408,7 +417,28 @@
     {{if .Trace.Span.Annotations}}
     <table class="table table-condensed table-striped">
       {{range (filterAnnotations .Trace.Span.Annotations)}}
-      <tr><th>{{.Key}}</th><td>{{str .Value}}</td></tr>
+        {{if .Important}}
+          <tr><th>{{.Key}}</th><td>{{str .Value}}</td></tr>
+        {{end}}
+      {{end}}
+    </table>
+    {{end}}
+  </li>
+</ul>
+
+<!-- The verbose data view layout -->
+<ul id="verboseDataView" class="traces">
+  <li class="trace" id="span-{{.Trace.Span.ID.Span}}">
+    {{if .Trace.Name}}
+    <strong title="{{.Trace.ID}}">{{.Trace.Name}}</strong>
+    {{else}}
+    <strong title="{{.Trace.ID}}">{{.Trace.ID.Span}}</strong>
+    {{end}}
+
+    {{if .Trace.Span.Annotations}}
+    <table class="table table-condensed table-striped">
+      {{range (filterAnnotations .Trace.Span.Annotations)}}
+        <tr><th>{{.Key}}</th><td>{{str .Value}}</td></tr>
       {{end}}
     </table>
     {{end}}

--- a/traceapp/tmpl/traces.html
+++ b/traceapp/tmpl/traces.html
@@ -19,7 +19,9 @@
         {{if .Span.Annotations}}
         <table class="table table-condensed table-striped">
           {{range (filterAnnotations .Span.Annotations)}}
-          <tr><th>{{.Key}}</th><td>{{str .Value}}</td></tr>
+            {{if .Important}}
+              <tr><th>{{.Key}}</th><td>{{str .Value}}</td></tr>
+            {{end}}
           {{end}}
         </table>
         {{end}}


### PR DESCRIPTION
This change allows events to optionally implement the `ImportantEvent` interface. It enables events to return a list of annotation keys (e.g. `Response.StatusCode`) which thye find particularly important. Annotation keys not marked as important _are considered to be verbose_.

The UI is updated to reflect this change -- by splitting the data view tab into two separate tabs _Data View_ (only displays important span annotations) and _Verbose Data View_ (displays all span annotations).

Consider the _Data View_ before:
***
![before_dataview](https://cloud.githubusercontent.com/assets/3173176/6428712/8805da98-bf68-11e4-8337-ba6396d06b1a.png)
***

It now renders as just:
***
![after_data_view](https://cloud.githubusercontent.com/assets/3173176/6428714/9c68ace0-bf68-11e4-8d9e-db15d359a592.png)
***

And the new _Verbose Data View_:
***
![after_verbose_dataview](https://cloud.githubusercontent.com/assets/3173176/6428718/b5cc52d6-bf68-11e4-9add-d37673745174.png)
***

Additionally the _Traces_ page before:
***
![before_traces](https://cloud.githubusercontent.com/assets/3173176/6428721/d8f5529e-bf68-11e4-82d8-7e73cfe07f49.png)
***

Has been updated to only display _important_ annotations (which makes navigating lots of traces far easier):
***
![after_traces](https://cloud.githubusercontent.com/assets/3173176/6428723/e5efcf88-bf68-11e4-97f9-42f83eb70612.png)
***

For a more extravagant example look at `appdash demo` which used to produce:
***
![after_http_demo](https://cloud.githubusercontent.com/assets/3173176/6428743/740cb6b4-bf69-11e4-9608-967c6e778992.png)
***

And now produces just:
***
![before_http_demo](https://cloud.githubusercontent.com/assets/3173176/6428736/49ccb430-bf69-11e4-863b-1c7eed0f7b3d.png)
***