### PR TITLE
Add more documentation

### DIFF
--- a/cmd/appdash/appdash.go
+++ b/cmd/appdash/appdash.go
@@ -1,3 +1,53 @@
+// Command appdash runs the Appdash web UI from the command-line.
+//
+// For information about Appdash see:
+//
+// https://sourcegraph.com/sourcegraph/appdash
+//
+// Demo mode
+//
+// A demo of Appdash in a small web application can be ran by simply running:
+//
+//  appdash demo
+//
+// Which will produce some output:
+//
+//  Appdash collector listening on tcp:46346
+//  Appdash web UI running at http://localhost:8700
+//
+//  Appdash demo app running at http://localhost:8699
+//
+// Visiting the demo app URL mentioned above will then bring up the demo app
+// which will make a few fake API calls, and then give you a direct link to
+// view the trace for your request in Appdash's web UI.
+//
+// Serve mode
+//
+// Basic usage consists of running:
+//
+//  appdash serve
+//
+// Which will start a Appdash collector server running on TCP port 7701 in
+// plain-text (i.e. insecure). The Appdash collector server can then receive
+// information from your application via a appdash.NewRemoteCollector, which it
+// will then display in the web UI.
+//
+// The web UI is also ran on HTTP port 7700, which you could visit in a
+// browser:
+//
+//  http://localhost:7700
+//
+// Optionally, you do not need to use this command at all and can embed the web
+// UI into your application directly on a separate HTTP port (see the traceapp
+// package or examples/cmd/webapp for more details).
+//
+// Send mode
+//
+// For testing purposes, the appdash command can send some fake data to a
+// remote Appdash collector server by running:
+//
+//  appdash send -c="localhost:7701"
+//
 package main
 
 import (

--- a/event.go
+++ b/event.go
@@ -8,6 +8,8 @@ import (
 
 // An Event is a record of the occurrence of something.
 type Event interface {
+	// Schema should return the event's schema, a constant string, for example
+	// the sqltrace package defines SQLEvent which returns just "SQL".
 	Schema() string
 }
 

--- a/event.go
+++ b/event.go
@@ -79,6 +79,16 @@ func UnmarshalEvent(as Annotations, e Event) error {
 }
 
 // RegisterEvent registers an event type for use with UnmarshalEvents.
+//
+// Events must be registered with this package in order for unmarshaling to
+// work. Much like the image package, sometimes blank imports will be used for
+// packages that register Appdash events with this package:
+//
+//  import(
+//      _ "sourcegraph.com/sourcegraph/appdash/httptrace"
+//      _ "sourcegraph.com/sourcegraph/appdash/sqltrace"
+//  )
+//
 func RegisterEvent(e Event) {
 	if _, present := registeredEvents[e.Schema()]; present {
 		panic("event schema is already registered: " + e.Schema())

--- a/store.go
+++ b/store.go
@@ -42,7 +42,8 @@ func NewMemoryStore() *MemoryStore {
 	}
 }
 
-// A MemoryStore is an in-memory Store.
+// A MemoryStore is an in-memory Store that also implements the PersistentStore
+// interface.
 type MemoryStore struct {
 	trace map[ID]*Trace        // trace ID -> trace tree
 	span  map[ID]map[ID]*Trace // trace ID -> span ID -> trace (sub)tree
@@ -243,7 +244,8 @@ type memoryStoreData struct {
 	Span  map[ID]map[ID]*Trace
 }
 
-// Write writes ms's internal data structures.
+// Write implements the PersistentStore interface by gob-encoding and writing
+// ms's internal data structures out to w.
 func (ms *MemoryStore) Write(w io.Writer) error {
 	ms.Lock()
 	defer ms.Unlock()
@@ -252,7 +254,8 @@ func (ms *MemoryStore) Write(w io.Writer) error {
 	return gob.NewEncoder(w).Encode(data)
 }
 
-// ReadFrom loads ms's internal data structures from a reader.
+// ReadFrom implements the PersistentStore interface by using gob-decoding to
+// load ms's internal data structures from the reader r.
 func (ms *MemoryStore) ReadFrom(r io.Reader) (int64, error) {
 	ms.Lock()
 	defer ms.Unlock()

--- a/traceapp/app.go
+++ b/traceapp/app.go
@@ -1,3 +1,14 @@
+// Package traceapp implements the Appdash web UI.
+//
+// The web UI can be effectively launched using the appdash command (see
+// cmd/appdash) or via embedding this package within your app.
+//
+// Templates and other resources needed by this package to render the UI are
+// built into the program using go-bindata, so you still get to have single
+// binary deployment.
+//
+// For an example of embedding the Appdash web UI within your own application
+// via the traceapp package, see the examples/cmd/webapp example.
 package traceapp
 
 import (


### PR DESCRIPTION
This change adds the last of the documentation that I wanted to target / felt was missing. Primarily this is high-level package and command docs, plus a few targeted ones (like the fact that `appdash.MemoryStore` implements the `appdash.PersistentStore` interface).

All other public symbols are documented properly (from my own extensive review, and according to `go vet` / `golint`).