### PR TITLE
Add a lot of benchmarks

### DIFF
--- a/collector_test.go
+++ b/collector_test.go
@@ -252,3 +252,22 @@ MCUXgckTpKCuGwbJk7424Nb8bLzf3kllAiA5mUBgjfr/WtFSJdWcPQ4Zt9KTMNKD
 EUO0ukpTwEIl6wIhAMbGqZK3zAAFdq8DD2jPx+UJXnh0rnOkZBzDtJ6/iN69AiEA
 1Aq8MJgTaYsDQWyU/hDq5YkDJc9e9DSCvUIzqxQWMQE=
 -----END RSA PRIVATE KEY-----`)
+
+func BenchmarkChunkedCollector500(b *testing.B) {
+	cc := &ChunkedCollector{
+		Collector: collectorFunc(func(span SpanID, anns ...Annotation) error {
+			return nil
+		}),
+		MinInterval: time.Millisecond * 10,
+	}
+	var x ID
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < 500; c++ {
+			x++
+			err := cc.Collect(SpanID{x, x + 1, x + 2})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/event_test.go
+++ b/event_test.go
@@ -194,3 +194,23 @@ func (dummyEvent) Schema() string { return "dummy" }
 type dummyEvent2 struct{ A, X string }
 
 func (dummyEvent2) Schema() string { return "dummy2" }
+
+func BenchmarkMarshalEvent(b *testing.B) {
+	e := dummyEvent{
+		A: "a",
+		B: "b",
+		C: 1,
+		D: map[string]string{"k1": "v1", "k2": "v2"},
+		E: "e",
+		F: dummyEventF{
+			G: "g",
+			H: map[string]string{"k3": "v3", "k4": "v4"},
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		_, err := MarshalEvent(e)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/event_test.go
+++ b/event_test.go
@@ -214,3 +214,18 @@ func BenchmarkMarshalEvent(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkUnmarshalEvents(b *testing.B) {
+	anns := Annotations{
+		{Key: "A", Value: []byte("a")},
+		{Key: "X", Value: []byte("x")},
+		{Key: "_schema:dummy"},
+		{Key: "_schema:dummy2"},
+	}
+	for i := 0; i < b.N; i++ {
+		var events []Event
+		if err := UnmarshalEvents(anns, &events); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/span_test.go
+++ b/span_test.go
@@ -172,3 +172,36 @@ type annotations Annotations
 func (a annotations) Len() int           { return len(a) }
 func (a annotations) Less(i, j int) bool { return a[i].Key < a[j].Key }
 func (a annotations) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func BenchmarkNewRootSpanID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewRootSpanID()
+	}
+}
+
+func BenchmarkNewSpanID(b *testing.B) {
+	root := NewRootSpanID()
+	for i := 0; i < b.N; i++ {
+		NewSpanID(root)
+	}
+}
+
+func BenchmarkSpanIDString(b *testing.B) {
+	id := SpanID{
+		Trace:  100,
+		Parent: 200,
+		Span:   300,
+	}
+	for i := 0; i < b.N; i++ {
+		id.String()
+	}
+}
+
+func BenchmarkParseSpanID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := ParseSpanID("0000000000000064/000000000000012c")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/store_test.go
+++ b/store_test.go
@@ -384,6 +384,32 @@ func init() {
 	log.SetFlags(0)
 }
 
+func benchmarkMemoryStoreN(b *testing.B, n int) {
+	ms := NewMemoryStore()
+	var x ID
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < n; c++ {
+			x++
+			err := ms.Collect(SpanID{x, x + 1, x + 2})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkMemoryStore100(b *testing.B) {
+	benchmarkMemoryStoreN(b, 100)
+}
+
+func BenchmarkMemoryStore250(b *testing.B) {
+	benchmarkMemoryStoreN(b, 250)
+}
+
+func BenchmarkMemoryStore1000(b *testing.B) {
+	benchmarkMemoryStoreN(b, 1000)
+}
+
 func BenchmarkRecentStore500(b *testing.B) {
 	rs := &RecentStore{
 		DeleteStore: NewMemoryStore(),


### PR DESCRIPTION
This change adds a bunch of benchmarks to the various `appdash` data types. Currently on my machine this reports:

```
BenchmarkChunkedCollector500    	    1000	   2447726 ns/op
BenchmarkMarshalEvent           	  100000	     16036 ns/op
BenchmarkUnmarshalEvents        	   50000	     35877 ns/op
BenchmarkIDGeneration           	10000000	       166 ns/op
BenchmarkFlatten                	  200000	      7431 ns/op
BenchmarkNewRootSpanID          	 5000000	       340 ns/op
BenchmarkNewSpanID              	10000000	       176 ns/op
BenchmarkSpanIDString           	  200000	      6694 ns/op
BenchmarkParseSpanID            	 2000000	       702 ns/op
BenchmarkMemoryStore100         	    3000	    555790 ns/op
BenchmarkMemoryStore250         	    2000	   1517543 ns/op
BenchmarkMemoryStore1000        	     300	   5345421 ns/op
BenchmarkMemoryStoreWrite1000   	     200	   6092708 ns/op
BenchmarkMemoryStoreReadFrom1000	     100	  11200728 ns/op
BenchmarkRecentStore500         	     500	   4793635 ns/op
``` 