### PR TITLE
Add the ability to import and export single traces

### DIFF
--- a/traceapp/router.go
+++ b/traceapp/router.go
@@ -15,6 +15,7 @@ const (
 	TraceSpanRoute        = "traceapp.trace.span"         // route name for a single trace sub-span page
 	TraceProfileRoute     = "traceapp.trace.profile"      // route name for a JSON trace profile
 	TraceSpanProfileRoute = "traceapp.trace.span.profile" // route name for a JSON trace sub-span profile
+	TraceUploadRoute      = "traceapp.trace.upload"       // route name for a JSON trace upload
 	TracesRoute           = "traceapp.traces"             // route name for traces page
 )
 
@@ -31,6 +32,7 @@ func NewRouter(base *mux.Router) *Router {
 	base.Path("/traces/{Trace}").Methods("GET").Name(TraceRoute)
 	base.Path("/traces/{Trace}/profile").Methods("GET").Name(TraceProfileRoute)
 	base.Path("/traces/{Trace}/{Span}/profile").Methods("GET").Name(TraceSpanProfileRoute)
+	base.Path("/traces/upload").Methods("POST").Name(TraceUploadRoute)
 	base.Path("/traces/{Trace}/{Span}").Methods("GET").Name(TraceSpanRoute)
 	base.Path("/traces").Methods("GET").Name(TracesRoute)
 	return &Router{base}

--- a/traceapp/tmpl/layout.html
+++ b/traceapp/tmpl/layout.html
@@ -6,7 +6,7 @@
     <title>{{template "Title" $}}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.6.0/bootstrap-table.min.css">
     <style>
@@ -29,6 +29,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.13/d3.js"></script>
     <script src="//rawgit.com/jiahuang/d3-timeline/master/src/d3-timeline.js"></script>
     <script src="//rawgit.com/krisk/fuse/master/src/fuse.min.js"></script>
+    <script src="//rawgit.com/zeroclipboard/zeroclipboard/master/dist/ZeroClipboard.min.js"></script>
   </head>
   <body>
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -1,8 +1,24 @@
 {{define "Title"}}{{if .Trace.ID.Parent}}span {{.Trace.ID.Span}} - {{end}} trace {{.Trace.ID.Trace}} - appdash{{end}}
 
 {{define "Main"}}
-<h1>Trace {{.Trace.ID.Trace}}</h1>
+<h1>Trace {{.Trace.ID.Trace}}
+  {{if not .Trace.ID.Parent}}
+    <span style="font-size: 12px; vertical-align: middle;">
+      (<a id="copy-json" data-clipboard-text="{{.Trace.String}}">Copy as JSON</a>)
+    </span>
+    {{end}}
+</h1>
 {{if .Trace.ID.Parent}}<h2>Sub-span {{.Trace.ID.Span}}</h2>{{end}}
+
+<script type="text/javascript">
+  var client = new ZeroClipboard( document.getElementById("copy-json") );
+
+  client.on("ready", function( readyEvent ) {
+    client.on("aftercopy", function( event ) {
+      alert("JSON Trace copied to clipboard.");
+    });
+  });
+</script>
 
 <div>
 <div id="#trace-{{.Trace.ID.Trace}}" class="trace-timeline"></div>
@@ -482,4 +498,3 @@
 </script>
 
 {{end}}
-

--- a/traceapp/tmpl/traces.html
+++ b/traceapp/tmpl/traces.html
@@ -1,7 +1,43 @@
 {{define "Title"}}Traces - appdash{{end}}
 
 {{define "Main"}}
+
+<!-- Styling for the import-json button & menu -->
+<style>
+  #import-json {
+    float: right;
+    position: relative;
+    top: 20px;
+  }
+  #import-json-menu {
+    display: none;
+  }
+  #import-json-menu>span {
+    margin-left: auto;
+  }
+</style>
+
+<!-- import-json button & page title -->
+<button class="btn btn-default" type="button" id="import-json">Import JSON</button>
 <h1>Traces</h1>
+
+<!-- import-json menu -->
+<div id="import-json-menu">
+  <!-- TextArea -->
+  <form role="form">
+    <div class="form-group">
+      <label for="comment">Import a JSON trace by pasting it below:</label>
+      <textarea autocomplete="off" class="form-control" rows="5" id="import-json-trace"></textarea>
+    </div>
+  </form>
+  <br/>
+  <!-- Import / Cancel buttons -->
+  <div class="btn-toolbar">
+    <button class="btn btn-default pull-right" type="button" id="import-json-complete">Import</button>
+    <button class="btn btn-default pull-right" type="button" id="import-json-cancel">Cancel</button>
+  </div>
+  <hr/>
+</div>
 
 <ul>
   {{range .Traces}}
@@ -30,4 +66,49 @@
   </li>
   {{end}}
 </ul>
+
+<!-- Bindings for the import-json menu -->
+<script type="text/javascript">
+  // Build a toggle function:
+  var menuVisible = false;
+  var toggleVisible = function(e) {
+    if(menuVisible) {
+      $("#import-json-menu").slideUp();
+      $("#import-json").fadeIn();
+    } else {
+      $("#import-json-menu").slideDown(function() {
+        $("#import-json-trace").focus();
+      });
+      $("#import-json").fadeOut();
+    }
+    menuVisible = !menuVisible;
+    e.preventDefault();
+  }
+
+  // When user clicks the "Import JSON" or "Cancel" buttons, toggle the menu
+  // visibility. Cancel as the toggle function works because it can only be
+  // clicked when the menu is visible.
+  $("#import-json").click(toggleVisible);
+  $("#import-json-cancel").click(toggleVisible);
+
+  // Upon completion of the import form, we POST the JSON trace data up to
+  // the "/traces/upload" URL and reload the page to display the new trace.
+  $("#import-json-complete").click(function() {
+    // Trim whitespace to ensure the user pasted something (plus, the server
+    // doesn't care about whitespace).
+    var data = $("#import-json-trace").val().trim();
+    if(data.length == 0) {
+      alert("Please input a valid JSON Trace!");
+      return;
+    }
+
+    // Upload the trace, refreshing page upon completion.
+    $.post("/traces/upload", data)
+      .done(function() { location.reload() })
+      .fail(function(xhr, textStatus, errorThrown) {
+        alert("error: " + xhr.responseText);
+      })
+  });
+</script>
+
 {{end}}

--- a/traceapp/trace.go
+++ b/traceapp/trace.go
@@ -1,0 +1,23 @@
+package traceapp
+
+import "sourcegraph.com/sourcegraph/appdash"
+
+// collectTrace asks the given collector to collect all of the spans and
+// annotations in the given trace recursively. Any errors that occur during
+// collectino are directly returned, breaking the recursive chain.
+func collectTrace(c appdash.Collector, t *appdash.Trace) error {
+	// Record this span's ID and annotations.
+	err := c.Collect(t.ID, t.Annotations...)
+	if err != nil {
+		return err
+	}
+
+	// Descend into sub-spans.
+	for _, sub := range t.Sub {
+		err = collectTrace(c, sub)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This change adds the ability to import and export single traces. A trace captured on one Appdash instance can be shared with other people as standard JSON-encoded text and imported directly into another retaining all information about the trace (spans, annotations, etc).

When viewing a specific trace there is now a _"Copy as JSON"_ link to the right of the trace ID, for example:

![screen shot 2015-03-12 at 10 01 31 pm](https://cloud.githubusercontent.com/assets/3173176/6633305/9e32d948-c903-11e4-9033-6c4f87a9013c.png)

***

At which point the JSON-encoded trace will be copied to your clipboard:

![screen shot 2015-03-12 at 10 04 05 pm](https://cloud.githubusercontent.com/assets/3173176/6633325/d31da5b6-c903-11e4-92a0-da6bd29666e4.png)

***

On the Traces overview page (`/traces`) there is a new _"Import JSON"_ button:

![screen shot 2015-03-12 at 10 06 23 pm](https://cloud.githubusercontent.com/assets/3173176/6633345/2af9532a-c904-11e4-93ab-8ccf32e64052.png)

***

Clicking the button slides out a textarea where you can paste a previously-exported JSON trace:

![screen shot 2015-03-12 at 10 07 40 pm](https://cloud.githubusercontent.com/assets/3173176/6633358/6622ceae-c904-11e4-813c-14e081332857.png)

Attempts to upload traces that are duplicates or would collide (i.e. merge with an existing trace) are met with an error alert.

After importing a JSON trace, the page is refreshed and the trace can be viewed normally through the UI.