### PR TITLE
Clean global js namespace

### DIFF
--- a/traceapp/tmpl/root.html
+++ b/traceapp/tmpl/root.html
@@ -4,40 +4,40 @@
 
 <style>
 .sub {
-	margin-left: 1em;
-	font-size: 16px;
+  margin-left: 1em;
+  font-size: 16px;
 }
 .footer {
-	text-align: center;
+  text-align: center;
 }
 </style>
 
 <h1>Welcome</h1>
 <div class="sub">
-	<p>Appdash is a performance and debug tracing suite for Go.</p>
-	<p>It allows for tracing the end-to-end performance of hierarchically structured applications (like distributed web apps). Appdash enables you to, for example, see detailed information of each HTTP request and SQL query made by an entire distributed web application.</p>
+  <p>Appdash is a performance and debug tracing suite for Go.</p>
+  <p>It allows for tracing the end-to-end performance of hierarchically structured applications (like distributed web apps). Appdash enables you to, for example, see detailed information of each HTTP request and SQL query made by an entire distributed web application.</p>
 </div>
 
 <hr/>
 <h2>Getting Started</h2>
 <div class="sub">
-	<p>To get started, click on the <em>Traces</em> tab at the top of this page. When a trace is collected it will show up there.</p>
-    <p>Tip: Try right clicking on a span to bring up the context menu!</p>
+  <p>To get started, click on the <em>Traces</em> tab at the top of this page. When a trace is collected it will show up there.</p>
+  <p>Tip: Try right clicking on a span to bring up the context menu!</p>
 </div>
 
 <hr/>
 <h2>More</h2>
 <div class="sub">
-	<p>Appdash is an open-source project hosted <a href="https://github.com/sourcegraph/appdash">on GitHub</a>, and you can use the <a href="https://github.com/sourcegraph/appdash/issues">issue tracker</a> to file an issue or request new features.</p>
+  <p>Appdash is an open-source project hosted <a href="https://github.com/sourcegraph/appdash">on GitHub</a>, and you can use the <a href="https://github.com/sourcegraph/appdash/issues">issue tracker</a> to file an issue or request new features.</p>
 </div>
 
 <div class="footer">
-	<br/>
-	<!-- SourceGraph badge -->
-	<img src="https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/appdash/.badges/docs-examples.png" alt="docs-examples">
+  <br/>
+  <!-- SourceGraph badge -->
+  <img src="https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/appdash/.badges/docs-examples.png" alt="docs-examples">
 
-	<!-- GoDoc badge -->
-	<a href="https://godoc.org/sourcegraph.com/sourcegraph/appdash"><img src="https://godoc.org/sourcegraph.com/sourcegraph/appdash?status.svg" alt="GoDoc"></a>
+  <!-- GoDoc badge -->
+  <a href="https://godoc.org/sourcegraph.com/sourcegraph/appdash"><img src="https://godoc.org/sourcegraph.com/sourcegraph/appdash?status.svg" alt="GoDoc"></a>
 </div>
 
 {{end}}

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -11,13 +11,15 @@
 {{if .Trace.ID.Parent}}<h2>Sub-span {{.Trace.ID.Span}}</h2>{{end}}
 
 <script type="text/javascript">
-  var client = new ZeroClipboard( document.getElementById("copy-json") );
+  (function() {
+    var client = new ZeroClipboard( document.getElementById("copy-json") );
 
-  client.on("ready", function( readyEvent ) {
-    client.on("aftercopy", function( event ) {
-      alert("JSON Trace copied to clipboard.");
+    client.on("ready", function( readyEvent ) {
+      client.on("aftercopy", function( event ) {
+        alert("JSON Trace copied to clipboard.");
+      });
     });
-  });
+  })();
 </script>
 
 <div>
@@ -102,271 +104,273 @@
 </style>
 
 <script type="text/javascript">
-  var data = {{.VisData}};
-  var width = $(".container").width(); 
+  (function() {
+    var data = {{.VisData}};
+    var width = $(".container").width();
 
-  // em converts the input (in em units) to pixels units and returns it.
-  function em(emUnits) {
-    var fontSize = parseFloat($('body').css('font-size'));
-    return fontSize * emUnits;
-  }
+    // em converts the input (in em units) to pixels units and returns it.
+    function em(emUnits) {
+      var fontSize = parseFloat($('body').css('font-size'));
+      return fontSize * emUnits;
+    }
 
-  // numFromEnd returns the number from the end of the potentially garbage
-  // string, e.g. "timelineItem_1443" -> 1443
-  function numFromEnd(str) {
-    return parseInt(str.match(/(\d+)$/)[0], 10);
-  }
+    // numFromEnd returns the number from the end of the potentially garbage
+    // string, e.g. "timelineItem_1443" -> 1443
+    function numFromEnd(str) {
+      return parseInt(str.match(/(\d+)$/)[0], 10);
+    }
 
-  // Initialize bootstrap tooltips.
-  $('[data-toggle="tooltip"]').tooltip();
+    // Initialize bootstrap tooltips.
+    $('[data-toggle="tooltip"]').tooltip();
 
-  // setChildrenVisible walks through the data and finds all children (including
-  // distant ones) of the given spanID. It marks each one as visible (true or
-  // false).
-  function setChildrenVisible(spanID, visible) {
-    $.each(data, function(i, other) {
-      if(other.parentSpanID != spanID) {
+    // setChildrenVisible walks through the data and finds all children (including
+    // distant ones) of the given spanID. It marks each one as visible (true or
+    // false).
+    function setChildrenVisible(spanID, visible) {
+      $.each(data, function(i, other) {
+        if(other.parentSpanID != spanID) {
+          return;
+        }
+        other.visible = visible;
+        setChildrenVisible(other.spanID, visible);
+      });
+    }
+
+    // cloneObjNoDots clones the given object (all of it's keys and values). It
+    // returns the clone, but with all keys containing dots (.) replaced with
+    // underscores. This is useful because Fuse treats keys with dots as accessors
+    // into sub-objects (not literally the key).
+    function cloneObjNoDots(o) {
+      var noDots = {};
+      $.each(o, function(k, v) {
+        noDots[k.replace(/\./g,'_')] = v
+      });
+      return noDots;
+    }
+
+    // filterChildrenFuzzy uses Fuse to fuzzy-search through the data (
+    // specifically, the names and tags) and hides all children elements that do
+    // not match.
+    function filterChildrenFuzzy(spanID, filter) {
+      // Fuse has a limitation of 32 character search pattern strings, so we just
+      // slice to 32 incase someone enters more (which would cause Fuse to raise
+      // an exception).
+      filter = filter.slice(0, 32);
+
+      // Recursively descend into each span showing and hiding each one based on
+      // our search results.
+      var descend = null;
+      descend = function(parentSpanID) {
+        $.each(data, function(i, other) {
+          // Check that the span we're looking at is a child of the given parent
+          // span.
+          if(other.parentSpanID != parentSpanID) {
+            return;
+          }
+
+          // Perform a fuzzy search on this spans' keys. We do this as not all
+          // spans have identical keys to search on, and Fuse wants specific keys
+          // to search on.
+          var r = cloneObjNoDots(other.rawData);
+          var fuse = new Fuse([r], {
+            caseSensitive: false,
+            shouldSort: true,
+            threshold: 0.3,       // A lower threshold is more strict, higher is less.
+            keys: Object.keys(r), // Data fields to search on.
+          });
+          var results = fuse.search(filter);
+
+          // Depending on whether or not the fuzzy search on this span turned up
+          // any results, the span is visible or hidden.
+          other.visible = results.length > 0;
+
+          // Descend into that span's children.
+          descend(other.spanID);
+        });
+      }
+      descend(spanID);
+    }
+
+    // filterChildren walks through the data and finds all children (including
+    // distant ones) of the given spanID. It uses a filter to mark each child span
+    // as visible or not.
+    //
+    // A strict search is defined by a key followed by a colon and a quoted value.
+    //
+    //  Key:"expected value"
+    //
+    // For example:
+    //
+    //  Name:"Request"
+    //
+    // If a filter does not match the above strict-searching pattern,
+    // filterChildren silently falls back to fuse-based fuzzy searching.
+    function filterChildren(spanID, filter) {
+      // Validate the filter.
+      var splitFilter = filter.split(":");
+      if(splitFilter.length != 2) {
+        // Missing colon for strict search, fallback to fuzzy search then.
+        filterChildrenFuzzy(spanID, filter);
         return;
       }
-      other.visible = visible;
-      setChildrenVisible(other.spanID, visible);
-    });
-  }
+      var k = splitFilter[0];
+      var v = splitFilter[1];
+      if(v[0] !== '"' || v[v.length-1] !== '"') {
+        // Missing quoted value for strict search, fallback to fuzzy search then.
+        filterChildrenFuzzy(spanID, filter);
+        return;
+      }
+      // Strip leading and trailing quotes from value:
+      v = v.slice(1, v.length-1);
 
-  // cloneObjNoDots clones the given object (all of it's keys and values). It
-  // returns the clone, but with all keys containing dots (.) replaced with
-  // underscores. This is useful because Fuse treats keys with dots as accessors
-  // into sub-objects (not literally the key).
-  function cloneObjNoDots(o) {
-    var noDots = {};
-    $.each(o, function(k, v) {
-      noDots[k.replace(/\./g,'_')] = v
-    });
-    return noDots;
-  }
-
-  // filterChildrenFuzzy uses Fuse to fuzzy-search through the data (
-  // specifically, the names and tags) and hides all children elements that do
-  // not match.
-  function filterChildrenFuzzy(spanID, filter) {
-    // Fuse has a limitation of 32 character search pattern strings, so we just
-    // slice to 32 incase someone enters more (which would cause Fuse to raise
-    // an exception).
-    filter = filter.slice(0, 32);
-
-    // Recursively descend into each span showing and hiding each one based on
-    // our search results.
-    var descend = null;
-    descend = function(parentSpanID) {
       $.each(data, function(i, other) {
-        // Check that the span we're looking at is a child of the given parent
-        // span.
-        if(other.parentSpanID != parentSpanID) {
+        if(other.parentSpanID != spanID) {
           return;
         }
 
-        // Perform a fuzzy search on this spans' keys. We do this as not all
-        // spans have identical keys to search on, and Fuse wants specific keys
-        // to search on.
-        var r = cloneObjNoDots(other.rawData);
-        var fuse = new Fuse([r], {
-          caseSensitive: false,
-          shouldSort: true,
-          threshold: 0.3,       // A lower threshold is more strict, higher is less.
-          keys: Object.keys(r), // Data fields to search on.
+        // Check if the span has a key and value exactly matching our filter.
+        if(other.rawData[k] == v) {
+          other.visible = true;
+        } else {
+          other.visible = false;
+        }
+        filterChildren(other.spanID, filter);
+      });
+    }
+
+    // When the user presses the Close button in the context menu, we hide it. We
+    // declare this as a separate function so that other context menu items can
+    // quickly hide the context menu as well (see below).
+    function ctxMenuActionClose(e) {
+      e.preventDefault();
+      $("#contextMenu").hide();
+    }
+    $('#contextMenu a[data-action="close"]').on("click", ctxMenuActionClose);
+
+    // ctxMenuActionShowHide is the implementation for the context menu's Show
+    // Children and Hide Children buttons.
+    function ctxMenuActionShowHide(e, visible) {
+      ctxMenuActionClose(e);
+      var spanID = $("#contextMenu").data("dataObject").spanID;
+      setChildrenVisible(spanID, visible)
+      timelineHover();
+    }
+
+    // Event handlers for each context menu Show/Hide button.
+    $('#contextMenu a[data-action="show-children"]').on("click", function(e) { ctxMenuActionShowHide(e, true) });
+    $('#contextMenu a[data-action="hide-children"]').on("click", function(e) { ctxMenuActionShowHide(e, false) });
+
+    // Event handler for the filter submenu.
+    $('#contextMenu a[data-action="filter"]').on("click", function(e) {
+      // Close the normal context menu.
+      ctxMenuActionClose(e);
+
+      // Display the submenu.
+      $("#contextFilterMenu .name").html($("#contextMenu .name").html());
+      $("#contextFilterMenu").css({
+        display: "block",
+        left: $("#contextMenu").css("left"),
+        top: $("#contextMenu").css("top")
+      });
+      $('#contextFilterMenu .filter').select();
+    });
+
+    // Hide the filter context-submenu when the user presses the close button.
+    $('#contextFilterMenu a[data-action="close"]').on("click", function(e) {
+      e.preventDefault();
+      $("#contextFilterMenu").hide();
+    });
+
+    // When the user types something into the filter text input and presses enter,
+    // we apply the filter to all children below the target span.
+    $('#contextFilterMenu .filter').keyup(function(e) {
+      if(e.keyCode != 13) {
+        return; // Not enter.
+      }
+      // Hide the context menu, grab the target span ID, and filter the children.
+      var spanID = $("#contextMenu").data("dataObject").spanID;
+      filterChildren(spanID, $(this).val())
+      $("#contextFilterMenu").hide();
+      timelineHover();
+    });
+
+    function ctxMenuOpen(e, datum, obj) {
+      $("#contextFilterMenu").hide();
+      $("#contextMenu").data("dataObject", obj);
+      $("#contextMenu .name").html(datum.label);
+      $("#contextMenu").css({
+        display: "block",
+        left: e.pageX,
+        top: e.pageY
+      });
+      return false;
+    }
+
+    function timelineHover() {
+      // When rebuilding the timeline to account for changes, we must first empty
+      // it completely.
+      $(".trace-timeline").empty();
+
+      // Copy just the visible objects of the data for passing into d3-timeline.
+      var visibleData = [];
+      $.each(data, function(i, obj) {
+        if(!obj.visible) {
+          return;
+        }
+        visibleData.push(obj);
+      });
+      if(visibleData.length == 0) {
+        return;
+      }
+
+      var timespanHover = function(chart, index) {
+        var div = $('#hoverRes');
+        var colors = chart.colors();
+        div.find('.coloredDiv').css('background-color', colors(index));
+        div.find('#name').text(visibleData[index].label);
+      }
+
+      // Initialize the timeline chart.
+      var chart = d3.timeline()
+                    .width(width)
+                    .stack()
+                    .margin({left:em(6), right:0, top:0, bottom:0})
+                    .hover(function (d, i, datum) { timespanHover(chart, i) })
+                    .click(function (d, i, datum) {
+                      window.location.href = datum.url;
+                      //alert(JSON.stringify(datum.rawData, null, 2));
+                    });
+      var svg = d3.select(".trace-timeline").append("svg").attr("width", width)
+                  .datum(visibleData).call(chart);
+
+      // Make text on each timeline element click-able. d3-timeline.js doesn't
+      // seem to have a way to support this easily.
+      //
+      // We do this by selecting the text element, finding the prev element (the
+      // SVG rect), and then parsing the ID (which looks like: "timelineItem_1").
+      //
+      // The last number of that is the index into our visibleData.
+      $(".trace-timeline g>text").each(function() {
+        var index = numFromEnd($(this).prev().attr('id'));
+        $(this).hover(function() {
+          timespanHover(chart, index);
         });
-        var results = fuse.search(filter);
+        $(this).click(function() {
+          window.location.href = visibleData[index].url;
+        });
 
-        // Depending on whether or not the fuzzy search on this span turned up
-        // any results, the span is visible or hidden.
-        other.visible = results.length > 0;
-
-        // Descend into that span's children.
-        descend(other.spanID);
+        // When there is a contextmenu (e.g. right click) event we open the
+        // context menu on the timespan rectangle.
+        var datum = d3.select($(this).prev()[0]).data()[0];
+        $(this).on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
+        $(this).prev().on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
       });
     }
-    descend(spanID);
-  }
 
-  // filterChildren walks through the data and finds all children (including
-  // distant ones) of the given spanID. It uses a filter to mark each child span
-  // as visible or not.
-  //
-  // A strict search is defined by a key followed by a colon and a quoted value.
-  //
-  //  Key:"expected value"
-  //
-  // For example:
-  //
-  //  Name:"Request"
-  //
-  // If a filter does not match the above strict-searching pattern,
-  // filterChildren silently falls back to fuse-based fuzzy searching.
-  function filterChildren(spanID, filter) {
-    // Validate the filter.
-    var splitFilter = filter.split(":");
-    if(splitFilter.length != 2) {
-      // Missing colon for strict search, fallback to fuzzy search then.
-      filterChildrenFuzzy(spanID, filter);
-      return;
+    if(data != null) {
+      timelineHover();
     }
-    var k = splitFilter[0];
-    var v = splitFilter[1];
-    if(v[0] !== '"' || v[v.length-1] !== '"') {
-      // Missing quoted value for strict search, fallback to fuzzy search then.
-      filterChildrenFuzzy(spanID, filter);
-      return;
-    }
-    // Strip leading and trailing quotes from value:
-    v = v.slice(1, v.length-1);
-
-    $.each(data, function(i, other) {
-      if(other.parentSpanID != spanID) {
-        return;
-      }
-
-      // Check if the span has a key and value exactly matching our filter.
-      if(other.rawData[k] == v) {
-        other.visible = true;
-      } else {
-        other.visible = false;
-      }
-      filterChildren(other.spanID, filter);
-    });
-  }
-
-  // When the user presses the Close button in the context menu, we hide it. We
-  // declare this as a separate function so that other context menu items can
-  // quickly hide the context menu as well (see below).
-  function ctxMenuActionClose(e) {
-    e.preventDefault();
-    $("#contextMenu").hide();
-  }
-  $('#contextMenu a[data-action="close"]').on("click", ctxMenuActionClose);
-
-  // ctxMenuActionShowHide is the implementation for the context menu's Show
-  // Children and Hide Children buttons.
-  function ctxMenuActionShowHide(e, visible) {
-    ctxMenuActionClose(e);
-    var spanID = $("#contextMenu").data("dataObject").spanID;
-    setChildrenVisible(spanID, visible)
-    timelineHover();
-  }
-
-  // Event handlers for each context menu Show/Hide button.
-  $('#contextMenu a[data-action="show-children"]').on("click", function(e) { ctxMenuActionShowHide(e, true) });
-  $('#contextMenu a[data-action="hide-children"]').on("click", function(e) { ctxMenuActionShowHide(e, false) });
-
-  // Event handler for the filter submenu.
-  $('#contextMenu a[data-action="filter"]').on("click", function(e) {
-    // Close the normal context menu.
-    ctxMenuActionClose(e);
-
-    // Display the submenu.
-    $("#contextFilterMenu .name").html($("#contextMenu .name").html());
-    $("#contextFilterMenu").css({
-      display: "block",
-      left: $("#contextMenu").css("left"),
-      top: $("#contextMenu").css("top")
-    });
-    $('#contextFilterMenu .filter').select();
-  });
-
-  // Hide the filter context-submenu when the user presses the close button.
-  $('#contextFilterMenu a[data-action="close"]').on("click", function(e) {
-    e.preventDefault();
-    $("#contextFilterMenu").hide();
-  });
-
-  // When the user types something into the filter text input and presses enter,
-  // we apply the filter to all children below the target span.
-  $('#contextFilterMenu .filter').keyup(function(e) {
-    if(e.keyCode != 13) {
-      return; // Not enter.
-    }
-    // Hide the context menu, grab the target span ID, and filter the children.
-    var spanID = $("#contextMenu").data("dataObject").spanID;
-    filterChildren(spanID, $(this).val())
-    $("#contextFilterMenu").hide();
-    timelineHover();
-  });
-
-  function ctxMenuOpen(e, datum, obj) {
-    $("#contextFilterMenu").hide();
-    $("#contextMenu").data("dataObject", obj);
-    $("#contextMenu .name").html(datum.label);
-    $("#contextMenu").css({
-      display: "block",
-      left: e.pageX,
-      top: e.pageY
-    });
-    return false;
-  }
-
-  function timelineHover() {
-    // When rebuilding the timeline to account for changes, we must first empty
-    // it completely.
-    $(".trace-timeline").empty();
-
-    // Copy just the visible objects of the data for passing into d3-timeline.
-    var visibleData = [];
-    $.each(data, function(i, obj) {
-      if(!obj.visible) {
-        return;
-      }
-      visibleData.push(obj);
-    });
-    if(visibleData.length == 0) {
-      return;
-    }
-
-    var timespanHover = function(chart, index) {
-      var div = $('#hoverRes');
-      var colors = chart.colors();
-      div.find('.coloredDiv').css('background-color', colors(index));
-      div.find('#name').text(visibleData[index].label);
-    }
-
-    // Initialize the timeline chart.
-    var chart = d3.timeline()
-                  .width(width)
-                  .stack()
-                  .margin({left:em(6), right:0, top:0, bottom:0})
-                  .hover(function (d, i, datum) { timespanHover(chart, i) })
-                  .click(function (d, i, datum) {
-                    window.location.href = datum.url;
-                    //alert(JSON.stringify(datum.rawData, null, 2));
-                  });
-    var svg = d3.select(".trace-timeline").append("svg").attr("width", width)
-                .datum(visibleData).call(chart);
-
-    // Make text on each timeline element click-able. d3-timeline.js doesn't
-    // seem to have a way to support this easily.
-    //
-    // We do this by selecting the text element, finding the prev element (the
-    // SVG rect), and then parsing the ID (which looks like: "timelineItem_1").
-    //
-    // The last number of that is the index into our visibleData.
-    $(".trace-timeline g>text").each(function() {
-      var index = numFromEnd($(this).prev().attr('id'));
-      $(this).hover(function() {
-        timespanHover(chart, index);
-      });
-      $(this).click(function() {
-        window.location.href = visibleData[index].url;
-      });
-
-      // When there is a contextmenu (e.g. right click) event we open the
-      // context menu on the timespan rectangle.
-      var datum = d3.select($(this).prev()[0]).data()[0];
-      $(this).on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
-      $(this).prev().on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
-    });
-  }
-
-  if(data != null) {
-    timelineHover();
-  }
+  })();
 </script>
 
 

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -55,330 +55,330 @@
 
 
 <style type="text/css">
- .axis path,
- .axis line {
-   fill: none;
-   stroke: black;
-   shape-rendering: crispEdges;
- }
- .axis text {
-   font-family: sans-serif;
-   font-size: 10px;
- }
- .timeline-label {
-   font-family: sans-serif;
-   font-size: 12px;
- }
- #timeline2 .axis {
-   transform: translate(0px,30px);
-   -ms-transform: translate(0px,30px); /* IE 9 */
-   -webkit-transform: translate(0px,30px); /* Safari and Chrome */
-   -o-transform: translate(0px,30px); /* Opera */
-   -moz-transform: translate(0px,30px); /* Firefox */
- }
- #hoverRes .coloredDiv {
-   height:20px; width:20px; float:left;
- }
- #hoverRes #name {
-   display: inline-block;
-   margin-left: 0.3em;
- }
- #contextMenu, #contextFilterMenu {
-   font-family: sans-serif;
-   font-size: 12px;
-   position: absolute;
-   display: none;
-   z-index: 100;
- }
- #contextMenu .dropdown-menu>li>span {
-   display: block;
-   padding: 3px 20px;
-   clear: both;
-   font-weight: 400;
-   line-height: 1.42857143;
-   color: #333;
-   white-space: nowrap;
- }
+  .axis path,
+  .axis line {
+    fill: none;
+    stroke: black;
+    shape-rendering: crispEdges;
+  }
+  .axis text {
+    font-family: sans-serif;
+    font-size: 10px;
+  }
+  .timeline-label {
+    font-family: sans-serif;
+    font-size: 12px;
+  }
+  #timeline2 .axis {
+    transform: translate(0px,30px);
+    -ms-transform: translate(0px,30px); /* IE 9 */
+    -webkit-transform: translate(0px,30px); /* Safari and Chrome */
+    -o-transform: translate(0px,30px); /* Opera */
+    -moz-transform: translate(0px,30px); /* Firefox */
+  }
+  #hoverRes .coloredDiv {
+    height:20px; width:20px; float:left;
+  }
+  #hoverRes #name {
+    display: inline-block;
+    margin-left: 0.3em;
+  }
+  #contextMenu, #contextFilterMenu {
+    font-family: sans-serif;
+    font-size: 12px;
+    position: absolute;
+    display: none;
+    z-index: 100;
+  }
+  #contextMenu .dropdown-menu>li>span {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: 400;
+    line-height: 1.42857143;
+    color: #333;
+    white-space: nowrap;
+  }
 </style>
 
 <script type="text/javascript">
- var data = {{.VisData}};
- var width = $(".container").width();
+  var data = {{.VisData}};
+  var width = $(".container").width(); 
 
- // em converts the input (in em units) to pixels units and returns it.
- function em(emUnits) {
-   var fontSize = parseFloat($('body').css('font-size'));
-   return fontSize * emUnits;
- }
+  // em converts the input (in em units) to pixels units and returns it.
+  function em(emUnits) {
+    var fontSize = parseFloat($('body').css('font-size'));
+    return fontSize * emUnits;
+  }
 
- // numFromEnd returns the number from the end of the potentially garbage
- // string, e.g. "timelineItem_1443" -> 1443
- function numFromEnd(str) {
-   return parseInt(str.match(/(\d+)$/)[0], 10);
- }
+  // numFromEnd returns the number from the end of the potentially garbage
+  // string, e.g. "timelineItem_1443" -> 1443
+  function numFromEnd(str) {
+    return parseInt(str.match(/(\d+)$/)[0], 10);
+  }
 
- // Initialize bootstrap tooltips.
- $('[data-toggle="tooltip"]').tooltip();
+  // Initialize bootstrap tooltips.
+  $('[data-toggle="tooltip"]').tooltip();
 
- // setChildrenVisible walks through the data and finds all children (including
- // distant ones) of the given spanID. It marks each one as visible (true or
- // false).
- function setChildrenVisible(spanID, visible) {
-   $.each(data, function(i, other) {
-     if(other.parentSpanID != spanID) {
-       return;
-     }
-     other.visible = visible;
-     setChildrenVisible(other.spanID, visible);
-   });
- }
+  // setChildrenVisible walks through the data and finds all children (including
+  // distant ones) of the given spanID. It marks each one as visible (true or
+  // false).
+  function setChildrenVisible(spanID, visible) {
+    $.each(data, function(i, other) {
+      if(other.parentSpanID != spanID) {
+        return;
+      }
+      other.visible = visible;
+      setChildrenVisible(other.spanID, visible);
+    });
+  }
 
- // cloneObjNoDots clones the given object (all of it's keys and values). It
- // returns the clone, but with all keys containing dots (.) replaced with
- // underscores. This is useful because Fuse treats keys with dots as accessors
- // into sub-objects (not literally the key).
- function cloneObjNoDots(o) {
-   var noDots = {};
-   $.each(o, function(k, v) {
-     noDots[k.replace(/\./g,'_')] = v
-   });
-   return noDots;
- }
+  // cloneObjNoDots clones the given object (all of it's keys and values). It
+  // returns the clone, but with all keys containing dots (.) replaced with
+  // underscores. This is useful because Fuse treats keys with dots as accessors
+  // into sub-objects (not literally the key).
+  function cloneObjNoDots(o) {
+    var noDots = {};
+    $.each(o, function(k, v) {
+      noDots[k.replace(/\./g,'_')] = v
+    });
+    return noDots;
+  }
 
- // filterChildrenFuzzy uses Fuse to fuzzy-search through the data (
- // specifically, the names and tags) and hides all children elements that do
- // not match.
- function filterChildrenFuzzy(spanID, filter) {
-   // Fuse has a limitation of 32 character search pattern strings, so we just
-   // slice to 32 incase someone enters more (which would cause Fuse to raise
-   // an exception).
-   filter = filter.slice(0, 32);
+  // filterChildrenFuzzy uses Fuse to fuzzy-search through the data (
+  // specifically, the names and tags) and hides all children elements that do
+  // not match.
+  function filterChildrenFuzzy(spanID, filter) {
+    // Fuse has a limitation of 32 character search pattern strings, so we just
+    // slice to 32 incase someone enters more (which would cause Fuse to raise
+    // an exception).
+    filter = filter.slice(0, 32);
 
-   // Recursively descend into each span showing and hiding each one based on
-   // our search results.
-   var descend = null;
-   descend = function(parentSpanID) {
-     $.each(data, function(i, other) {
-       // Check that the span we're looking at is a child of the given parent
-       // span.
-       if(other.parentSpanID != parentSpanID) {
-         return;
-       }
+    // Recursively descend into each span showing and hiding each one based on
+    // our search results.
+    var descend = null;
+    descend = function(parentSpanID) {
+      $.each(data, function(i, other) {
+        // Check that the span we're looking at is a child of the given parent
+        // span.
+        if(other.parentSpanID != parentSpanID) {
+          return;
+        }
 
-       // Perform a fuzzy search on this spans' keys. We do this as not all
-       // spans have identical keys to search on, and Fuse wants specific keys
-       // to search on.
-       var r = cloneObjNoDots(other.rawData);
-       var fuse = new Fuse([r], {
-         caseSensitive: false,
-         shouldSort: true,
-         threshold: 0.3,       // A lower threshold is more strict, higher is less.
-         keys: Object.keys(r), // Data fields to search on.
-       });
-       var results = fuse.search(filter);
+        // Perform a fuzzy search on this spans' keys. We do this as not all
+        // spans have identical keys to search on, and Fuse wants specific keys
+        // to search on.
+        var r = cloneObjNoDots(other.rawData);
+        var fuse = new Fuse([r], {
+          caseSensitive: false,
+          shouldSort: true,
+          threshold: 0.3,       // A lower threshold is more strict, higher is less.
+          keys: Object.keys(r), // Data fields to search on.
+        });
+        var results = fuse.search(filter);
 
-       // Depending on whether or not the fuzzy search on this span turned up
-       // any results, the span is visible or hidden.
-       other.visible = results.length > 0;
+        // Depending on whether or not the fuzzy search on this span turned up
+        // any results, the span is visible or hidden.
+        other.visible = results.length > 0;
 
-       // Descend into that span's children.
-       descend(other.spanID);
-     });
-   }
-   descend(spanID);
- }
+        // Descend into that span's children.
+        descend(other.spanID);
+      });
+    }
+    descend(spanID);
+  }
 
- // filterChildren walks through the data and finds all children (including
- // distant ones) of the given spanID. It uses a filter to mark each child span
- // as visible or not.
- //
- // A strict search is defined by a key followed by a colon and a quoted value.
- //
- //  Key:"expected value"
- //
- // For example:
- //
- //  Name:"Request"
- //
- // If a filter does not match the above strict-searching pattern,
- // filterChildren silently falls back to fuse-based fuzzy searching.
- function filterChildren(spanID, filter) {
-   // Validate the filter.
-   var splitFilter = filter.split(":");
-   if(splitFilter.length != 2) {
-     // Missing colon for strict search, fallback to fuzzy search then.
-     filterChildrenFuzzy(spanID, filter);
-     return;
-   }
-   var k = splitFilter[0];
-   var v = splitFilter[1];
-   if(v[0] !== '"' || v[v.length-1] !== '"') {
-     // Missing quoted value for strict search, fallback to fuzzy search then.
-     filterChildrenFuzzy(spanID, filter);
-     return;
-   }
-   // Strip leading and trailing quotes from value:
-   v = v.slice(1, v.length-1);
+  // filterChildren walks through the data and finds all children (including
+  // distant ones) of the given spanID. It uses a filter to mark each child span
+  // as visible or not.
+  //
+  // A strict search is defined by a key followed by a colon and a quoted value.
+  //
+  //  Key:"expected value"
+  //
+  // For example:
+  //
+  //  Name:"Request"
+  //
+  // If a filter does not match the above strict-searching pattern,
+  // filterChildren silently falls back to fuse-based fuzzy searching.
+  function filterChildren(spanID, filter) {
+    // Validate the filter.
+    var splitFilter = filter.split(":");
+    if(splitFilter.length != 2) {
+      // Missing colon for strict search, fallback to fuzzy search then.
+      filterChildrenFuzzy(spanID, filter);
+      return;
+    }
+    var k = splitFilter[0];
+    var v = splitFilter[1];
+    if(v[0] !== '"' || v[v.length-1] !== '"') {
+      // Missing quoted value for strict search, fallback to fuzzy search then.
+      filterChildrenFuzzy(spanID, filter);
+      return;
+    }
+    // Strip leading and trailing quotes from value:
+    v = v.slice(1, v.length-1);
 
-   $.each(data, function(i, other) {
-     if(other.parentSpanID != spanID) {
-       return;
-     }
+    $.each(data, function(i, other) {
+      if(other.parentSpanID != spanID) {
+        return;
+      }
 
-     // Check if the span has a key and value exactly matching our filter.
-     if(other.rawData[k] == v) {
-       other.visible = true;
-     } else {
-       other.visible = false;
-     }
-     filterChildren(other.spanID, filter);
-   });
- }
+      // Check if the span has a key and value exactly matching our filter.
+      if(other.rawData[k] == v) {
+        other.visible = true;
+      } else {
+        other.visible = false;
+      }
+      filterChildren(other.spanID, filter);
+    });
+  }
 
- // When the user presses the Close button in the context menu, we hide it. We
- // declare this as a separate function so that other context menu items can
- // quickly hide the context menu as well (see below).
- function ctxMenuActionClose(e) {
-   e.preventDefault();
-   $("#contextMenu").hide();
- }
- $('#contextMenu a[data-action="close"]').on("click", ctxMenuActionClose);
+  // When the user presses the Close button in the context menu, we hide it. We
+  // declare this as a separate function so that other context menu items can
+  // quickly hide the context menu as well (see below).
+  function ctxMenuActionClose(e) {
+    e.preventDefault();
+    $("#contextMenu").hide();
+  }
+  $('#contextMenu a[data-action="close"]').on("click", ctxMenuActionClose);
 
- // ctxMenuActionShowHide is the implementation for the context menu's Show
- // Children and Hide Children buttons.
- function ctxMenuActionShowHide(e, visible) {
-   ctxMenuActionClose(e);
-   var spanID = $("#contextMenu").data("dataObject").spanID;
-   setChildrenVisible(spanID, visible)
-   timelineHover();
- }
+  // ctxMenuActionShowHide is the implementation for the context menu's Show
+  // Children and Hide Children buttons.
+  function ctxMenuActionShowHide(e, visible) {
+    ctxMenuActionClose(e);
+    var spanID = $("#contextMenu").data("dataObject").spanID;
+    setChildrenVisible(spanID, visible)
+    timelineHover();
+  }
 
- // Event handlers for each context menu Show/Hide button.
- $('#contextMenu a[data-action="show-children"]').on("click", function(e) { ctxMenuActionShowHide(e, true) });
- $('#contextMenu a[data-action="hide-children"]').on("click", function(e) { ctxMenuActionShowHide(e, false) });
+  // Event handlers for each context menu Show/Hide button.
+  $('#contextMenu a[data-action="show-children"]').on("click", function(e) { ctxMenuActionShowHide(e, true) });
+  $('#contextMenu a[data-action="hide-children"]').on("click", function(e) { ctxMenuActionShowHide(e, false) });
 
- // Event handler for the filter submenu.
- $('#contextMenu a[data-action="filter"]').on("click", function(e) {
-   // Close the normal context menu.
-   ctxMenuActionClose(e);
+  // Event handler for the filter submenu.
+  $('#contextMenu a[data-action="filter"]').on("click", function(e) {
+    // Close the normal context menu.
+    ctxMenuActionClose(e);
 
-   // Display the submenu.
-   $("#contextFilterMenu .name").html($("#contextMenu .name").html());
-   $("#contextFilterMenu").css({
-     display: "block",
-     left: $("#contextMenu").css("left"),
-     top: $("#contextMenu").css("top")
-   });
-   $('#contextFilterMenu .filter').select();
- });
+    // Display the submenu.
+    $("#contextFilterMenu .name").html($("#contextMenu .name").html());
+    $("#contextFilterMenu").css({
+      display: "block",
+      left: $("#contextMenu").css("left"),
+      top: $("#contextMenu").css("top")
+    });
+    $('#contextFilterMenu .filter').select();
+  });
 
- // Hide the filter context-submenu when the user presses the close button.
- $('#contextFilterMenu a[data-action="close"]').on("click", function(e) {
-   e.preventDefault();
-   $("#contextFilterMenu").hide();
- });
+  // Hide the filter context-submenu when the user presses the close button.
+  $('#contextFilterMenu a[data-action="close"]').on("click", function(e) {
+    e.preventDefault();
+    $("#contextFilterMenu").hide();
+  });
 
- // When the user types something into the filter text input and presses enter,
- // we apply the filter to all children below the target span.
- $('#contextFilterMenu .filter').keyup(function(e) {
-   if(e.keyCode != 13) {
-     return; // Not enter.
-   }
-   // Hide the context menu, grab the target span ID, and filter the children.
-   var spanID = $("#contextMenu").data("dataObject").spanID;
-   filterChildren(spanID, $(this).val())
-   $("#contextFilterMenu").hide();
-   timelineHover();
- });
+  // When the user types something into the filter text input and presses enter,
+  // we apply the filter to all children below the target span.
+  $('#contextFilterMenu .filter').keyup(function(e) {
+    if(e.keyCode != 13) {
+      return; // Not enter.
+    }
+    // Hide the context menu, grab the target span ID, and filter the children.
+    var spanID = $("#contextMenu").data("dataObject").spanID;
+    filterChildren(spanID, $(this).val())
+    $("#contextFilterMenu").hide();
+    timelineHover();
+  });
 
- function ctxMenuOpen(e, datum, obj) {
-   $("#contextFilterMenu").hide();
-   $("#contextMenu").data("dataObject", obj);
-   $("#contextMenu .name").html(datum.label);
-   $("#contextMenu").css({
-     display: "block",
-     left: e.pageX,
-     top: e.pageY
-   });
-   return false;
- }
+  function ctxMenuOpen(e, datum, obj) {
+    $("#contextFilterMenu").hide();
+    $("#contextMenu").data("dataObject", obj);
+    $("#contextMenu .name").html(datum.label);
+    $("#contextMenu").css({
+      display: "block",
+      left: e.pageX,
+      top: e.pageY
+    });
+    return false;
+  }
 
- function timelineHover() {
-   // When rebuilding the timeline to account for changes, we must first empty
-   // it completely.
-   $(".trace-timeline").empty();
+  function timelineHover() {
+    // When rebuilding the timeline to account for changes, we must first empty
+    // it completely.
+    $(".trace-timeline").empty();
 
-   // Copy just the visible objects of the data for passing into d3-timeline.
-   var visibleData = [];
-   $.each(data, function(i, obj) {
-     if(!obj.visible) {
-       return;
-     }
-     visibleData.push(obj);
-   });
-   if(visibleData.length == 0) {
-     return;
-   }
+    // Copy just the visible objects of the data for passing into d3-timeline.
+    var visibleData = [];
+    $.each(data, function(i, obj) {
+      if(!obj.visible) {
+        return;
+      }
+      visibleData.push(obj);
+    });
+    if(visibleData.length == 0) {
+      return;
+    }
 
-   var timespanHover = function(chart, index) {
-     var div = $('#hoverRes');
-     var colors = chart.colors();
-     div.find('.coloredDiv').css('background-color', colors(index));
-     div.find('#name').text(visibleData[index].label);
-   }
+    var timespanHover = function(chart, index) {
+      var div = $('#hoverRes');
+      var colors = chart.colors();
+      div.find('.coloredDiv').css('background-color', colors(index));
+      div.find('#name').text(visibleData[index].label);
+    }
 
-   // Initialize the timeline chart.
-   var chart = d3.timeline()
-                 .width(width)
-                 .stack()
-                 .margin({left:em(6), right:0, top:0, bottom:0})
-                 .hover(function (d, i, datum) { timespanHover(chart, i) })
-                 .click(function (d, i, datum) {
-                   window.location.href = datum.url;
-                   //alert(JSON.stringify(datum.rawData, null, 2));
-                 });
-   var svg = d3.select(".trace-timeline").append("svg").attr("width", width)
-               .datum(visibleData).call(chart);
+    // Initialize the timeline chart.
+    var chart = d3.timeline()
+                  .width(width)
+                  .stack()
+                  .margin({left:em(6), right:0, top:0, bottom:0})
+                  .hover(function (d, i, datum) { timespanHover(chart, i) })
+                  .click(function (d, i, datum) {
+                    window.location.href = datum.url;
+                    //alert(JSON.stringify(datum.rawData, null, 2));
+                  });
+    var svg = d3.select(".trace-timeline").append("svg").attr("width", width)
+                .datum(visibleData).call(chart);
 
-   // Make text on each timeline element click-able. d3-timeline.js doesn't
-   // seem to have a way to support this easily.
-   //
-   // We do this by selecting the text element, finding the prev element (the
-   // SVG rect), and then parsing the ID (which looks like: "timelineItem_1").
-   //
-   // The last number of that is the index into our visibleData.
-   $(".trace-timeline g>text").each(function() {
-     var index = numFromEnd($(this).prev().attr('id'));
-     $(this).hover(function() {
-       timespanHover(chart, index);
-     });
-     $(this).click(function() {
-       window.location.href = visibleData[index].url;
-     });
+    // Make text on each timeline element click-able. d3-timeline.js doesn't
+    // seem to have a way to support this easily.
+    //
+    // We do this by selecting the text element, finding the prev element (the
+    // SVG rect), and then parsing the ID (which looks like: "timelineItem_1").
+    //
+    // The last number of that is the index into our visibleData.
+    $(".trace-timeline g>text").each(function() {
+      var index = numFromEnd($(this).prev().attr('id'));
+      $(this).hover(function() {
+        timespanHover(chart, index);
+      });
+      $(this).click(function() {
+        window.location.href = visibleData[index].url;
+      });
 
-     // When there is a contextmenu (e.g. right click) event we open the
-     // context menu on the timespan rectangle.
-     var datum = d3.select($(this).prev()[0]).data()[0];
-     $(this).on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
-     $(this).prev().on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
-   });
- }
+      // When there is a contextmenu (e.g. right click) event we open the
+      // context menu on the timespan rectangle.
+      var datum = d3.select($(this).prev()[0]).data()[0];
+      $(this).on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
+      $(this).prev().on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
+    });
+  }
 
- if(data != null) {
-   timelineHover();
- }
+  if(data != null) {
+    timelineHover();
+  }
 </script>
 
 
 <!-- Trace Table -->
 <style type="text/css">
- .viewMode {
-   padding-top: 1em;
-   padding-bottom: 1em;
- }
- #profileView, #verboseDataView {
-   display: none;
- }
+  .viewMode {
+    padding-top: 1em;
+    padding-bottom: 1em;
+  }
+  #profileView, #verboseDataView {
+    display: none;
+  }
 </style>
 
 <!-- Justified radio-buttons for switching between data and profile views -->
@@ -400,24 +400,24 @@
 -->
 <script type="text/javascript">
   $(".viewMode input:radio").change(function(){
-     var id = $(this).attr("id");
-     if(id == "btnDataView") {
-       $("#dataView").show();
-     } else {
-       $("#dataView").hide();
-     }
+      var id = $(this).attr("id");
+      if(id == "btnDataView") {
+        $("#dataView").show();
+      } else {
+        $("#dataView").hide();
+      }
 
-     if(id == "btnVerboseDataView") {
-       $("#verboseDataView").show();
-     } else {
-       $("#verboseDataView").hide();
-     }
+      if(id == "btnVerboseDataView") {
+        $("#verboseDataView").show();
+      } else {
+        $("#verboseDataView").hide();
+      }
 
-     if(id == "btnProfileView") {
-       $("#profileView").show();
-     } else {
-       $("#profileView").hide();
-     }
+      if(id == "btnProfileView") {
+        $("#profileView").show();
+      } else {
+        $("#profileView").hide();
+      }
   });
 </script>
 
@@ -490,11 +490,11 @@
  proper sub-span page.
 -->
 <script type="text/javascript">
- $("#profileView .table").on('click-row.bs.table', function (e, row, $element) {
-   if(window.location.pathname != row.URL) {
-     window.location.href = row.URL;
-   }
- });
+  $("#profileView .table").on('click-row.bs.table', function (e, row, $element) {
+    if(window.location.pathname != row.URL) {
+      window.location.href = row.URL;
+    }
+  });
 </script>
 
 {{end}}

--- a/traceapp/tmpl/traces.html
+++ b/traceapp/tmpl/traces.html
@@ -69,46 +69,48 @@
 
 <!-- Bindings for the import-json menu -->
 <script type="text/javascript">
-  // Build a toggle function:
-  var menuVisible = false;
-  var toggleVisible = function(e) {
-    if(menuVisible) {
-      $("#import-json-menu").slideUp();
-      $("#import-json").fadeIn();
-    } else {
-      $("#import-json-menu").slideDown(function() {
-        $("#import-json-trace").focus();
-      });
-      $("#import-json").fadeOut();
-    }
-    menuVisible = !menuVisible;
-    e.preventDefault();
-  }
-
-  // When user clicks the "Import JSON" or "Cancel" buttons, toggle the menu
-  // visibility. Cancel as the toggle function works because it can only be
-  // clicked when the menu is visible.
-  $("#import-json").click(toggleVisible);
-  $("#import-json-cancel").click(toggleVisible);
-
-  // Upon completion of the import form, we POST the JSON trace data up to
-  // the "/traces/upload" URL and reload the page to display the new trace.
-  $("#import-json-complete").click(function() {
-    // Trim whitespace to ensure the user pasted something (plus, the server
-    // doesn't care about whitespace).
-    var data = $("#import-json-trace").val().trim();
-    if(data.length == 0) {
-      alert("Please input a valid JSON Trace!");
-      return;
+  (function() {
+    // Build a toggle function:
+    var menuVisible = false;
+    var toggleVisible = function(e) {
+      if(menuVisible) {
+        $("#import-json-menu").slideUp();
+        $("#import-json").fadeIn();
+      } else {
+        $("#import-json-menu").slideDown(function() {
+          $("#import-json-trace").focus();
+        });
+        $("#import-json").fadeOut();
+      }
+      menuVisible = !menuVisible;
+      e.preventDefault();
     }
 
-    // Upload the trace, refreshing page upon completion.
-    $.post("/traces/upload", data)
-      .done(function() { location.reload() })
-      .fail(function(xhr, textStatus, errorThrown) {
-        alert("error: " + xhr.responseText);
-      })
-  });
+    // When user clicks the "Import JSON" or "Cancel" buttons, toggle the menu
+    // visibility. Cancel as the toggle function works because it can only be
+    // clicked when the menu is visible.
+    $("#import-json").click(toggleVisible);
+    $("#import-json-cancel").click(toggleVisible);
+
+    // Upon completion of the import form, we POST the JSON trace data up to
+    // the "/traces/upload" URL and reload the page to display the new trace.
+    $("#import-json-complete").click(function() {
+      // Trim whitespace to ensure the user pasted something (plus, the server
+      // doesn't care about whitespace).
+      var data = $("#import-json-trace").val().trim();
+      if(data.length == 0) {
+        alert("Please input a valid JSON Trace!");
+        return;
+      }
+
+      // Upload the trace, refreshing page upon completion.
+      $.post("/traces/upload", data)
+        .done(function() { location.reload() })
+        .fail(function(xhr, textStatus, errorThrown) {
+          alert("error: " + xhr.responseText);
+        })
+    });
+  })();
 </script>
 
 {{end}}


### PR DESCRIPTION
Variables declared in JS through a simple:

```
var x = 0;
```

Are said to live in the global namespace. They can conflict with one another at any point. We use a few separate `<script>` tags for documentation and code separation purposes -- so it's hard to ensure that they do not declare conflicting variables and interfere with one another.

Instead, we now use an anonymous closure whose variables etc are local to that function's scope. For example:

```
(function() {
  var x = 0;
})();
```

The diff is probably not very readable due to the old code being out-dented by two additional spaces now. But the above should make the intent of this change clear.

Can be merged after Travis is done checking #49 (or I'll re-base and send again if further changes are needed). 