### PR TITLE
Prefix httptrace keys with Server/Client for clarity

### DIFF
--- a/httptrace/client.go
+++ b/httptrace/client.go
@@ -49,10 +49,10 @@ func requestInfo(r *http.Request) RequestInfo {
 
 // ClientEvent records an HTTP client request event.
 type ClientEvent struct {
-	Request    RequestInfo
-	Response   ResponseInfo
-	ClientSend time.Time
-	ClientRecv time.Time
+	Request    RequestInfo  `trace:"Client.Request"`
+	Response   ResponseInfo `trace:"Client.Response"`
+	ClientSend time.Time    `trace:"Client.Send"`
+	ClientRecv time.Time    `trace:"Client.Recv"`
 }
 
 // Schema returns the constant "HTTPClient".
@@ -61,9 +61,9 @@ func (ClientEvent) Schema() string { return "HTTPClient" }
 // Important implements the appdash ImportantEvent.
 func (ClientEvent) Important() []string {
 	return []string{
-		"Request.Headers.If-Modified-Since",
-		"Request.Headers.If-None-Match",
-		"Response.StatusCode",
+		"Client.Request.Headers.If-Modified-Since",
+		"Client.Request.Headers.If-None-Match",
+		"Client.Response.StatusCode",
 	}
 }
 

--- a/httptrace/server.go
+++ b/httptrace/server.go
@@ -40,12 +40,12 @@ func responseInfo(r *http.Response) ResponseInfo {
 
 // ServerEvent records an HTTP server request handling event.
 type ServerEvent struct {
-	Request    RequestInfo
-	Response   ResponseInfo
-	Route      string
-	User       string
-	ServerRecv time.Time
-	ServerSend time.Time
+	Request    RequestInfo  `trace:"Server.Request"`
+	Response   ResponseInfo `trace:"Server.Response"`
+	Route      string       `trace:"Server.Route"`
+	User       string       `trace:"Server.User"`
+	ServerRecv time.Time    `trace:"Server.Recv"`
+	ServerSend time.Time    `trace:"Server.Send"`
 }
 
 // Schema returns the constant "HTTPServer".
@@ -53,7 +53,7 @@ func (ServerEvent) Schema() string { return "HTTPServer" }
 
 // Important implements the appdash ImportantEvent.
 func (ServerEvent) Important() []string {
-	return []string{"Response.StatusCode"}
+	return []string{"Server.Response.StatusCode"}
 }
 
 // Start implements the appdash TimespanEvent interface.

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -4,7 +4,14 @@
 <h1>Trace {{.Trace.ID.Trace}}
   {{if not .Trace.ID.Parent}}
     <span style="font-size: 12px; vertical-align: middle;">
-      (<a id="copy-json" data-clipboard-text="{{.Trace.String}}">Copy as JSON</a>)
+      <!--
+        Note the [] brackets around the trace JSON string. We add these as we
+        support exporting/importing multiple traces as a json array type. The
+        Trace.String method just gives us a single JSON-encoded Trace object,
+        but using arrays across the entire system simplifies the encoding and
+        decoding processes slightly.
+      -->
+      (<a id="copy-json" data-clipboard-text="[{{.Trace.String}}]">Copy as JSON</a>)
     </span>
     {{end}}
 </h1>

--- a/traceapp/tmpl/traces.html
+++ b/traceapp/tmpl/traces.html
@@ -4,10 +4,8 @@
 
 <!-- Styling for the import-json button & menu -->
 <style>
-  #import-json {
-    float: right;
-    position: relative;
-    top: 20px;
+  #top-right-btns {
+    margin-top: 25px;
   }
   #import-json-menu {
     display: none;
@@ -15,10 +13,37 @@
   #import-json-menu>span {
     margin-left: auto;
   }
+  // Offset for the checkbox because it's not actually vertically aligned with
+  // the text.
+  .trace-checkbox {
+    // This doesn't fix the issue:
+    //vertical-align: middle;
+    position: relative;
+    top: 2px;
+  }
 </style>
 
-<!-- import-json button & page title -->
-<button class="btn btn-default" type="button" id="import-json">Import JSON</button>
+<!-- Top-Right Menu -->
+<div class="btn-group pull-right" role="group" aria-label="..." id="top-right-btns">
+  <!-- Import JSON button -->
+  <button class="btn btn-default" type="button" id="import-json"
+    title="import JSON traces directly into Appdash">Import JSON</button>
+
+  <!-- Traces options menu -->
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="view options for multiple selected traces">
+    Traces <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <li><a href="#" id="toggle-selection" title="select/deselect all traces">Toggle Selection</a></li>
+    <li><a id="export-to-json" title="copy the selected traces to the clipboard as JSON data">Export Selected</a></li>
+
+    <!-- TODO(slimsag): implement aggregate view
+    <li><a href="#" id="aggregate-view" title="view the aggregated data of the traces">Aggregate View</a></li>
+    -->
+  </ul>
+</div>
+
+<!-- page title -->
 <h1>Traces</h1>
 
 <!-- import-json menu -->
@@ -39,9 +64,11 @@
   <hr/>
 </div>
 
-<ul>
+<ul class="list-unstyled">
   {{range .Traces}}
   <li>
+    <input type="checkbox" class="trace-checkbox" checked="yes"
+    data-json-trace="{{.String}}">
     <a href="{{urlToTrace .Span.ID.Trace}}">{{.Span.ID.Trace}}</a>
 
     <ul class="traces">
@@ -67,8 +94,8 @@
   {{end}}
 </ul>
 
-<!-- Bindings for the import-json menu -->
 <script type="text/javascript">
+  // Bindings for the import-json menu.
   (function() {
     // Build a toggle function:
     var menuVisible = false;
@@ -109,6 +136,42 @@
         .fail(function(xhr, textStatus, errorThrown) {
           alert("error: " + xhr.responseText);
         })
+    });
+  })();
+
+  // Bindings for the traces options menu.
+  (function() {
+    // selected returns an array of the parsed JSON trace data for each selected
+    // trace.
+    var selected = function() {
+      var traces = [];
+      $(".trace-checkbox").each(function(i, e) {
+        if($(this).prop("checked")) {
+          var j = $(this).attr("data-json-trace");
+          traces.push($.parseJSON(j));
+        }
+      });
+      return traces;
+    }
+
+    // Export Selected button.
+    var exportToJSON = new ZeroClipboard($("#export-to-json"));
+    exportToJSON.on("copy", function(e) {
+      var sel = selected();
+      if(sel.length == 0) {
+        return;
+      }
+      // Note: 2 is the indention level.
+      exportToJSON.setText(JSON.stringify(sel, null, 2));
+      alert(sel.length + " JSON traces copied to clipboard.")
+    });
+
+    // Toggle Selection button.
+    var checked = true;
+    $("#toggle-selection").click(function(e) {
+      e.preventDefault();
+      checked = !checked;
+      $(".trace-checkbox").prop("checked", checked);
     });
   })();
 </script>


### PR DESCRIPTION
This change prefixes the fields (using the `trace` struct tag) of `httptrace.ServerEvent` and `httptrace.ClientEvent`.

For details about why this change is important, please see the linked issue. But in short:

Before:
***
![before](https://cloud.githubusercontent.com/assets/3173176/6742436/f9c008f0-ce4c-11e4-880f-47976c7288e9.png)
***

After:
***
![after](https://cloud.githubusercontent.com/assets/3173176/6742434/f411addc-ce4c-11e4-9cdd-ee6c6dbfea5d.png)
***

Fixes issue #45.

Note: waiting on Travis build of #51 (hence included change). 