### PR TITLE
Sorted traces

### DIFF
--- a/httptrace/client.go
+++ b/httptrace/client.go
@@ -49,10 +49,10 @@ func requestInfo(r *http.Request) RequestInfo {
 
 // ClientEvent records an HTTP client request event.
 type ClientEvent struct {
-	Request    RequestInfo
-	Response   ResponseInfo
-	ClientSend time.Time
-	ClientRecv time.Time
+	Request    RequestInfo  `trace:"Client.Request"`
+	Response   ResponseInfo `trace:"Client.Response"`
+	ClientSend time.Time    `trace:"Client.Send"`
+	ClientRecv time.Time    `trace:"Client.Recv"`
 }
 
 // Schema returns the constant "HTTPClient".
@@ -61,9 +61,9 @@ func (ClientEvent) Schema() string { return "HTTPClient" }
 // Important implements the appdash ImportantEvent.
 func (ClientEvent) Important() []string {
 	return []string{
-		"Request.Headers.If-Modified-Since",
-		"Request.Headers.If-None-Match",
-		"Response.StatusCode",
+		"Client.Request.Headers.If-Modified-Since",
+		"Client.Request.Headers.If-None-Match",
+		"Client.Response.StatusCode",
 	}
 }
 

--- a/httptrace/server.go
+++ b/httptrace/server.go
@@ -40,12 +40,12 @@ func responseInfo(r *http.Response) ResponseInfo {
 
 // ServerEvent records an HTTP server request handling event.
 type ServerEvent struct {
-	Request    RequestInfo
-	Response   ResponseInfo
-	Route      string
-	User       string
-	ServerRecv time.Time
-	ServerSend time.Time
+	Request    RequestInfo  `trace:"Server.Request"`
+	Response   ResponseInfo `trace:"Server.Response"`
+	Route      string       `trace:"Server.Route"`
+	User       string       `trace:"Server.User"`
+	ServerRecv time.Time    `trace:"Server.Recv"`
+	ServerSend time.Time    `trace:"Server.Send"`
 }
 
 // Schema returns the constant "HTTPServer".
@@ -53,7 +53,7 @@ func (ServerEvent) Schema() string { return "HTTPServer" }
 
 // Important implements the appdash ImportantEvent.
 func (ServerEvent) Important() []string {
-	return []string{"Response.StatusCode"}
+	return []string{"Server.Response.StatusCode"}
 }
 
 // Start implements the appdash TimespanEvent interface.

--- a/traceapp/app.go
+++ b/traceapp/app.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
 	"sync"
 
 	"github.com/gorilla/mux"
@@ -140,6 +141,11 @@ func (a *App) serveTraces(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
+
+	// Sort the traces by ID to ensure that the display order doesn't change upon
+	// multiple page reloads if Queryer.Traces is e.g. backed by a map (which has
+	// a random iteration order).
+	sort.Sort(tracesByID(traces))
 
 	return a.renderTemplate(w, r, "traces.html", http.StatusOK, &struct {
 		TemplateCommon

--- a/traceapp/trace.go
+++ b/traceapp/trace.go
@@ -21,3 +21,11 @@ func collectTrace(c appdash.Collector, t *appdash.Trace) error {
 	}
 	return nil
 }
+
+type tracesByID []*appdash.Trace
+
+func (t tracesByID) Len() int      { return len(t) }
+func (t tracesByID) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t tracesByID) Less(i, j int) bool {
+	return t[i].Span.ID.Trace.String() < t[j].Span.ID.Trace.String()
+}


### PR DESCRIPTION
This change sorts the traces displayed on the _Traces_ page so that reloading the page multiple times does not shift them randomly.

Fixes issue #47.

Can be merged after the Travis build for #52 runs.