### PR TITLE
traceapp: switch to a nicer UI design

### DIFF
--- a/traceapp/app.go
+++ b/traceapp/app.go
@@ -21,9 +21,11 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/mux"
 
 	"sourcegraph.com/sourcegraph/appdash"
+	static "sourcegraph.com/sourcegraph/appdash-data"
 )
 
 // App is an HTTP application handler that also exposes methods for
@@ -55,6 +57,12 @@ func New(r *Router) *App {
 	r.r.Get(TraceUploadRoute).Handler(handlerFunc(app.serveTraceUpload))
 	r.r.Get(TracesRoute).Handler(handlerFunc(app.serveTraces))
 
+	// Static file serving.
+	r.r.Get(StaticRoute).Handler(http.StripPrefix("/static/", http.FileServer(&assetfs.AssetFS{
+		Asset:    static.Asset,
+		AssetDir: static.AssetDir,
+		Prefix:   "",
+	})))
 	return app
 }
 

--- a/traceapp/router.go
+++ b/traceapp/router.go
@@ -11,6 +11,7 @@ import (
 // Traceapp's route names.
 const (
 	RootRoute             = "traceapp.root"               // route name for root
+	StaticRoute           = "traceapp.static"             // route name for static data files
 	TraceRoute            = "traceapp.trace"              // route name for a single trace page
 	TraceSpanRoute        = "traceapp.trace.span"         // route name for a single trace sub-span page
 	TraceProfileRoute     = "traceapp.trace.profile"      // route name for a JSON trace profile
@@ -29,6 +30,7 @@ func NewRouter(base *mux.Router) *Router {
 		base = mux.NewRouter()
 	}
 	base.Path("/").Methods("GET").Name(RootRoute)
+	base.PathPrefix("/static/").Methods("GET").Name(StaticRoute)
 	base.Path("/traces/{Trace}").Methods("GET").Name(TraceRoute)
 	base.Path("/traces/{Trace}/profile").Methods("GET").Name(TraceProfileRoute)
 	base.Path("/traces/{Trace}/{Span}/profile").Methods("GET").Name(TraceSpanProfileRoute)

--- a/traceapp/tmpl/data.go
+++ b/traceapp/tmpl/data.go
@@ -110,6 +110,17 @@ func Asset(name string) ([]byte, error) {
 	return nil, fmt.Errorf("Asset %s not found", name)
 }
 
+// MustAsset is like Asset but panics when Asset would return an error.
+// It simplifies safe initialization of global variables.
+func MustAsset(name string) []byte {
+	a, err := Asset(name)
+	if err != nil {
+		panic("asset: Asset(" + name + "): " + err.Error())
+	}
+
+	return a
+}
+
 // AssetInfo loads and returns the asset info for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.

--- a/traceapp/tmpl/layout.html
+++ b/traceapp/tmpl/layout.html
@@ -6,11 +6,25 @@
     <title>{{template "Title" $}}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
+    <link rel="icon" type="image/png" href="/static/favicon.png" />
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.6.0/bootstrap-table.min.css">
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <style>
-     body { padding-top: 50px; }
+     html {
+       position: relative;
+       min-height: 100%;
+     }
+     body {
+       padding-top: 50px;
+       background-color: #f2f2f2;
+       color: #333333;
+       font-family: 'Open Sans', sans-serif;
+
+       /* Margin bottom by footer height */
+       margin-bottom: 60px;
+     }
      .d0 { background-color: #bbb; }
      .d1 { background-color: #ccb7b7; }
      .d2 { background-color: #cca7a7; }
@@ -22,6 +36,51 @@
      .d8 { background-color: #cc2a2a; }
      .d9 { background-color: #cc1c1c; }
      .d10 { background-color: #cc0e0e; }
+
+     /* Navigation bar colors */
+     .navbar-inverse {
+       background-color: #333333;
+       border: none;
+     }
+
+     /* Navigation bar link colors */
+     .navbar-inverse .navbar-nav>li>a {
+       color: #f2f2f2;
+     }
+     .navbar-inverse .navbar-nav>li>a:hover, .navbar-inverse .navbar-nav>li>a:focus {
+       color: #ddd;
+     }
+     .navbar-inverse .navbar-nav>.active>a, .navbar-inverse .navbar-nav>.active>a:hover, .navbar-inverse .navbar-nav>.active>a:focus {
+       color: black;
+       background-color: #f2f2f2;
+     }
+     #logo {
+       width: auto;
+       height: 40px;
+       margin: 5px;
+       margin-right: 1em;
+     }
+
+     .ico-navbar {
+       font-size: 30px;
+       position: relative;
+       top: -4px;
+       float: left;
+       padding-right: .3em;
+     }
+
+     .footer {
+       position: absolute;
+       bottom: 0;
+       width: 100%;
+       /* Set the fixed height of the footer here */
+       height: 60px;
+       background-color: #f5f5f5;
+       text-align: center;
+     }
+     .footer a {
+       text-decoration: underline;
+     }
     </style>
     <script src="//code.jquery.com/jquery-2.1.1.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
@@ -41,11 +100,27 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{{.BaseURL}}">appdash</a>
+          <a href="{{.BaseURL}}" class="pull-left"><img id="logo" src="/static/logo_white.png"></a>
         </div>
-        <div id="navbar" class="collapse navbar-collapse">
+        <div id="navbar" class="collapse navbar-collapse pull-right">
           <ul class="nav navbar-nav">
-            <li {{if eq .CurrentRoute "traceapp.traces"}}class="active"{{end}}><a href="traces">Traces</a></li>
+
+            <li {{if eq .CurrentRoute "traceapp.traces"}}class="active"{{end}}>
+              <a href="traces">
+                <i class="fa fa-area-chart ico-navbar"></i> Traces
+              </a>
+            </li>
+
+            <li>
+              <a href="https://godoc.org/sourcegraph.com/sourcegraph/appdash" target="_blank">
+                <i class="fa fa-book ico-navbar"></i> Docs
+              </a>
+            </li>
+            <li>
+              <a href="https://github.com/sourcegraph/appdash" target="_blank">
+                <i class="fa fa-github ico-navbar"></i> GitHub
+              </a>
+            </li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -54,6 +129,65 @@
     <div class="container">
       {{template "Main" $}}
     </div>
+
+    <footer class="footer">
+      <div class="container">
+        <p class="text-muted">Appdash is an open-source project created by <a href="https://sourcegraph.com/">Sourcegraph</a>.</p>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var hints = [
+          'Appdash provides a Go HTTP middleware in the <a target="_blank" href="https://godoc.org/sourcegraph.com/sourcegraph/appdash/httptrace">appdash/httptrace</a> package!',
+          'It can be used from <a target="_blank" href="https://sourcegraph.com/sourcegraph.com/sourcegraph/appdash@master/.tree/python">within Python applications</a> too! Awesome!',
+          'Hint: Click the <u>Copy as JSON</strong> button to export a trace as JSON and share it with your friends!',
+          'Hint: The <strong>Verbose Data View</strong> tab shows all of the data associated with the current span.',
+          'Hint: The <strong>Profile View</strong> tab lets you see a trace just like in a profiler!',
+          'Hint: Click on any span (the colored rectangles) to narrow in on it and see its meta-data!',
+          'Hint: On the <strong>Traces<strong> page you can select and export multiple traces as JSON!',
+          'Hint: Import a JSON trace from another Appdash instance by clicking <strong>Import JSON</strong> button on the <strong>Traces</strong> page!'
+        ];
+
+        // nextHint returns the next hint in the hints array that has not been
+        // previously displayed.
+        var usedHints = [];
+        var lastHint = null;
+        function nextHint(i) {
+          var n = Math.floor((Math.random() * 1e9) % hints.length);
+
+          // First iteration? Start with a new random number then.
+          if(i == null || i == lastHint) {
+            return nextHint(n);
+          }
+
+          // Clear usedHints array when it is full.
+          if(usedHints.length >= hints.length) {
+            usedHints = [];
+          }
+
+          // Determine if the hint i has been used already.
+          $.each(usedHints, function(unused, e) {
+            if(e == i) {
+              // Used already, try the next random number.
+              return nextHint(n);
+            }
+          });
+
+          lastHint = i;
+          usedHints.push(i);
+          return i;
+        }
+
+        function displayHint()
+        {
+          $(".footer p").fadeOut(function() {
+            $(this).html(hints[nextHint(null)]).fadeIn();
+          });
+        }
+        setInterval(displayHint, 10000);
+      })();
+    </script>
   </body>
 </html>
 {{end}}

--- a/traceapp/tmpl/root.html
+++ b/traceapp/tmpl/root.html
@@ -10,34 +10,33 @@
 .footer {
   text-align: center;
 }
+.red-logo {
+  padding-top: 2.5em;
+}
+.red-spinner {
+  padding-top: 2.5em;
+}
+#big-btn {
+  margin: auto;
+  width: 21em;
+  padding-top: 5.5em;
+}
+#big-btn i {
+  line-height: 0; /* do not effect the height of the button */
+  font-size: 30px;
+  position: relative;
+  top: 3px;
+}
 </style>
 
-<h1>Welcome</h1>
-<div class="sub">
-  <p>Appdash is a performance and debug tracing suite for Go.</p>
-  <p>It allows for tracing the end-to-end performance of hierarchically structured applications (like distributed web apps). Appdash enables you to, for example, see detailed information of each HTTP request and SQL query made by an entire distributed web application.</p>
-</div>
+<img class="red-logo img-responsive center-block" src="/static/logo_red.png"></img>
+<h3 style="text-align: center;">Application tracing system for Go.</h3>
+<img class="red-spinner img-responsive center-block" src="/static/red_spinner.png"></img>
 
-<hr/>
-<h2>Getting Started</h2>
-<div class="sub">
-  <p>To get started, click on the <em>Traces</em> tab at the top of this page. When a trace is collected it will show up there.</p>
-  <p>Tip: Try right clicking on a span to bring up the context menu!</p>
-</div>
-
-<hr/>
-<h2>More</h2>
-<div class="sub">
-  <p>Appdash is an open-source project hosted <a href="https://github.com/sourcegraph/appdash">on GitHub</a>, and you can use the <a href="https://github.com/sourcegraph/appdash/issues">issue tracker</a> to file an issue or request new features.</p>
-</div>
-
-<div class="footer">
-  <br/>
-  <!-- SourceGraph badge -->
-  <img src="https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/appdash/.badges/docs-examples.png" alt="docs-examples">
-
-  <!-- GoDoc badge -->
-  <a href="https://godoc.org/sourcegraph.com/sourcegraph/appdash"><img src="https://godoc.org/sourcegraph.com/sourcegraph/appdash?status.svg" alt="GoDoc"></a>
+<div id="big-btn">
+  <a href="/traces" class="btn btn-block btn-lg btn-danger">
+    <i class="fa fa-area-chart big-btn"></i> View Traces
+  </a>
 </div>
 
 {{end}}

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -390,6 +390,12 @@
   #profileView, #verboseDataView {
     display: none;
   }
+  .fixed-table-container {
+    border: none;
+  }
+  .table th {
+    font-weight: normal;
+  }
 </style>
 
 <!-- Justified radio-buttons for switching between data and profile views -->


### PR DESCRIPTION
This change switches to a nicer UI design overall for the `traceapp` package.

The static image files are built into the final single-binary using `go-bindata` and `go-bindata-assetfs` to serve them (also see the new [appdash-data](https://github.com/sourcegraph/appdash-data) repository).

Home page before:
---
![before_home](https://cloud.githubusercontent.com/assets/3173176/6853685/d49c5a3a-d3a9-11e4-9748-3432a850e085.png)
---

Home page after:
---
![after_home](https://cloud.githubusercontent.com/assets/3173176/6853693/dcb2902c-d3a9-11e4-8a74-9557a467c215.png)
---
Take note that the footer at the bottom of the page which says "Appdash is an open-source project created by Sourcegraph." starts out that way, and then changes every 10 seconds into a random helpful-hint about using Appdash.


Traces page before:
---
![before_traces](https://cloud.githubusercontent.com/assets/3173176/6853707/f035012a-d3a9-11e4-9901-2cf2ae50b73b.png)
---

Traces page after:
---
![after_traces](https://cloud.githubusercontent.com/assets/3173176/6853709/f7e58dc2-d3a9-11e4-9289-eed02c211d13.png)
---

Traceview before:
---
![before_traceview](https://cloud.githubusercontent.com/assets/3173176/6853717/02b57de8-d3aa-11e4-9747-f80cc98ec3f8.png)
---

Traceview after:
---
![after_traceview](https://cloud.githubusercontent.com/assets/3173176/6853722/0c328ae6-d3aa-11e4-9577-4febb5b26d17.png)
---