### PR TITLE
traceapp: add Aggregate View

### DIFF
--- a/traceapp/aggregate.go
+++ b/traceapp/aggregate.go
@@ -1,0 +1,44 @@
+package traceapp
+
+import "sourcegraph.com/sourcegraph/appdash"
+
+// aggItem represents a set of traces with the name (label) and their cumulative
+// time.
+type aggItem struct {
+	Label string `json:"label"`
+	Value int64  `json:"value"`
+}
+
+// aggregate aggregates and encodes the given traces as JSON to the given writer.
+func (a *App) aggregate(traces []*appdash.Trace) ([]*aggItem, error) {
+	aggregated := make(map[string]*aggItem)
+	for _, trace := range traces {
+		// Calculate the cumulative time -- which we can already get through the
+		// profile view's calculation method.
+		_, prof, err := a.calcProfile(nil, trace)
+		if err != nil {
+			return nil, err
+		}
+
+		// Grab the aggregation item for the named trace, or create a new one if it
+		// does not already exist.
+		i, ok := aggregated[prof.Name]
+		if !ok {
+			i = &aggItem{Label: prof.Name}
+			aggregated[prof.Name] = i
+		}
+
+		// Perform aggregation.
+		i.Value += prof.TimeCum
+		if i.Value == 0 {
+			i.Value = 1 // Must be positive values or else d3pie won't render.
+		}
+	}
+
+	// Form an array (d3pie needs a JSON array, not a map).
+	list := make([]*aggItem, 0, len(aggregated))
+	for _, item := range aggregated {
+		list = append(list, item)
+	}
+	return list, nil
+}

--- a/traceapp/router.go
+++ b/traceapp/router.go
@@ -18,6 +18,7 @@ const (
 	TraceSpanProfileRoute = "traceapp.trace.span.profile" // route name for a JSON trace sub-span profile
 	TraceUploadRoute      = "traceapp.trace.upload"       // route name for a JSON trace upload
 	TracesRoute           = "traceapp.traces"             // route name for traces page
+	AggregateRoute        = "traceapp.aggregate"          // route name for aggregate trace view
 )
 
 // Router is a URL router for traceapp applications. It should be created via
@@ -37,6 +38,7 @@ func NewRouter(base *mux.Router) *Router {
 	base.Path("/traces/upload").Methods("POST").Name(TraceUploadRoute)
 	base.Path("/traces/{Trace}/{Span}").Methods("GET").Name(TraceSpanRoute)
 	base.Path("/traces").Methods("GET").Name(TracesRoute)
+	base.Path("/aggregate").Methods("GET").Name(AggregateRoute)
 	return &Router{base}
 }
 

--- a/traceapp/tmpl.go
+++ b/traceapp/tmpl.go
@@ -27,6 +27,7 @@ var templates = [][]string{
 	{"root.html", "layout.html"},
 	{"trace.html", "layout.html"},
 	{"traces.html", "layout.html"},
+	{"aggregate.html", "layout.html"},
 }
 
 // TemplateCommon is data that is passed to (and available to) all templates.

--- a/traceapp/tmpl/aggregate.html
+++ b/traceapp/tmpl/aggregate.html
@@ -1,0 +1,63 @@
+
+{{define "Title"}}Aggregate View - appdash{{end}}
+{{define "Main"}}
+<h1>Aggregated View</h1>
+
+<style type="text/css">
+  html,body {
+    /* Disable vertical scrollbar due to canvas being very long. */
+    overflow-y: hidden;
+  }
+  #pieChart {
+    width: 800px;
+    height: 600px;
+    margin-left: auto;
+    margin-right: auto;
+
+    /*
+      Canvas is very long, so we offset it by 100px. We could hange the canvas
+      size but it would effectively crop out some of the labels extending outward
+      from the chart
+    */
+    position: relative;
+    top: -100px;
+  }
+</style>
+
+<div id="pieChart"></div>
+
+<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.4/d3.min.js"></script>
+<script src="//rawgit.com/benkeen/d3pie/master/d3pie/d3pie.min.js"></script>
+<script type="text/javascript">
+  $(window).load(function() {
+    // Grab the aggregated data from the template parameter, or if there is
+		// none, fake a single data element for the pie chart to still render.
+    var data = {{.Aggregated}};
+    if(data.length == 0) {
+      data = [{"label": "no traces to aggregate", "value": 1}];
+    }
+
+		// Create the pie chart.
+    var pie = new d3pie("pieChart", {
+      "size": {
+        "canvasHeight": 800,
+        "canvasWidth": 800,
+        "pieInnerRadius": "80%",
+      },
+      "tooltips": {
+        "enabled": true,
+        "type": "placeholder",
+        "string": "{label} - {value}ms - {percentage}%",
+        "styles": {
+          "backgroundOpacity": 0.75
+        }
+      },
+      "data": {
+        "sortOrder": "value-desc",
+        "content": data
+      }
+    });
+  });
+</script>
+
+{{end}}

--- a/traceapp/tmpl/data.go
+++ b/traceapp/tmpl/data.go
@@ -23,6 +23,24 @@ type asset struct {
 	info  os.FileInfo
 }
 
+// aggregate_html reads file data from disk. It returns an error on failure.
+func aggregate_html() (*asset, error) {
+	path := filepath.Join(rootDir, "aggregate.html")
+	name := "aggregate.html"
+	bytes, err := bindata_read(path, name)
+	if err != nil {
+		return nil, err
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		err = fmt.Errorf("Error reading asset info %s at %s: %v", name, path, err)
+	}
+
+	a := &asset{bytes: bytes, info: fi}
+	return a, err
+}
+
 // layout_html reads file data from disk. It returns an error on failure.
 func layout_html() (*asset, error) {
 	path := filepath.Join(rootDir, "layout.html")
@@ -147,10 +165,11 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"layout.html": layout_html,
-	"root.html":   root_html,
-	"trace.html":  trace_html,
-	"traces.html": traces_html,
+	"aggregate.html": aggregate_html,
+	"layout.html":    layout_html,
+	"root.html":      root_html,
+	"trace.html":     trace_html,
+	"traces.html":    traces_html,
 }
 
 // AssetDir returns the file names below a certain
@@ -194,10 +213,11 @@ type _bintree_t struct {
 }
 
 var _bintree = &_bintree_t{nil, map[string]*_bintree_t{
-	"layout.html": &_bintree_t{layout_html, map[string]*_bintree_t{}},
-	"root.html":   &_bintree_t{root_html, map[string]*_bintree_t{}},
-	"trace.html":  &_bintree_t{trace_html, map[string]*_bintree_t{}},
-	"traces.html": &_bintree_t{traces_html, map[string]*_bintree_t{}},
+	"aggregate.html": &_bintree_t{aggregate_html, map[string]*_bintree_t{}},
+	"layout.html":    &_bintree_t{layout_html, map[string]*_bintree_t{}},
+	"root.html":      &_bintree_t{root_html, map[string]*_bintree_t{}},
+	"trace.html":     &_bintree_t{trace_html, map[string]*_bintree_t{}},
+	"traces.html":    &_bintree_t{traces_html, map[string]*_bintree_t{}},
 }}
 
 // Restore an asset under the given directory

--- a/traceapp/tmpl/traces.html
+++ b/traceapp/tmpl/traces.html
@@ -36,10 +36,7 @@
   <ul class="dropdown-menu" role="menu">
     <li><a href="#" id="toggle-selection" title="select/deselect all traces">Toggle Selection</a></li>
     <li><a id="export-to-json" title="copy the selected traces to the clipboard as JSON data">Export Selected</a></li>
-
-    <!-- TODO(slimsag): implement aggregate view
-    <li><a href="#" id="aggregate-view" title="view the aggregated data of the traces">Aggregate View</a></li>
-    -->
+    <li><a href="#" id="aggregate-view" title="view the aggregated data of the selected traces">Aggregate View</a></li>
   </ul>
 </div>
 
@@ -136,8 +133,8 @@
         .fail(function(xhr, textStatus, errorThrown) {
           alert("error: " + xhr.responseText);
         })
-    });
-  })();
+      });
+    })();
 
   // Bindings for the traces options menu.
   (function() {
@@ -172,6 +169,28 @@
       e.preventDefault();
       checked = !checked;
       $(".trace-checkbox").prop("checked", checked);
+    });
+
+    // Aggregate View button.
+    $("#aggregate-view").click(function(e) {
+      e.preventDefault();
+      var sel = selected();
+
+      // If we've selected everything, avoid sending a very long URL query
+      // parameter by just going straight to /aggregate which, by default, shows
+      // aggregated data for all traces.
+      if(sel.length == $(".trace-checkbox").length) {
+        window.location.href = {{.BaseURL.String}} + "aggregate";
+        return;
+      }
+
+      // Send the preceding POST request with the IDs we are interested in
+      // viewing, and then GET the /aggregate page.
+      var ids = [];
+      $.each(sel, function(i, trace) {
+        ids.push(trace.ID.Trace);
+      });
+      window.location.href = {{.BaseURL.String}} + "aggregate?selection=" + ids.join();
     });
   })();
 </script>


### PR DESCRIPTION
This change adds an aggregated data view for viewing multiple traces aggregated together. The idea is that all traces with the same name are joined together, and their total time spent is shown in the sorted pie-chart (rendered via [d3pie](http://d3pie.org/)).

To open aggregate view simply go to the _Traces_ page and select the traces you'd like to view, click the _Traces_ drop-down and select _Aggregate View_:

---
![menu](https://cloud.githubusercontent.com/assets/3173176/6949701/d890f8ec-d86a-11e4-8432-28231230c4ab.png)
---

Selecting just five traces produces a page showing the cumulative time of just those five traces, showing that the traces named `zri.ozruamwe.ll` took the most time (25% of all selected traces):

---
![just_five](https://cloud.githubusercontent.com/assets/3173176/6949720/f06f620a-d86a-11e4-8f56-c4b9075d282f.png)
---

Of course, using it on _all 60 traces_ produces a much more interesting result:

---
![all_60](https://cloud.githubusercontent.com/assets/3173176/6949796/627cf5c4-d86b-11e4-9bc4-56c6c05f04b4.png)
---

Showing that `fia.com` took 14% of the total time, followed by `web.kraesey.net` at 12%, and so on.