### PR TITLE
traceapp: load external assets not backed by a CDN from appdash-data

### DIFF
--- a/traceapp/tmpl/aggregate.html
+++ b/traceapp/tmpl/aggregate.html
@@ -27,7 +27,7 @@
 <div id="pieChart"></div>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.4/d3.min.js"></script>
-<script src="//rawgit.com/benkeen/d3pie/master/d3pie/d3pie.min.js"></script>
+<script src="{{.BaseURL}}static/benkeen/d3pie/d3pie.min.js"></script>
 <script type="text/javascript">
   $(window).load(function() {
     // Grab the aggregated data from the template parameter, or if there is

--- a/traceapp/tmpl/layout.html
+++ b/traceapp/tmpl/layout.html
@@ -86,9 +86,9 @@
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.6.0/bootstrap-table.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.13/d3.js"></script>
-    <script src="//rawgit.com/jiahuang/d3-timeline/master/src/d3-timeline.js"></script>
-    <script src="//rawgit.com/krisk/fuse/master/src/fuse.min.js"></script>
-    <script src="//rawgit.com/zeroclipboard/zeroclipboard/master/dist/ZeroClipboard.min.js"></script>
+    <script src="{{.BaseURL}}static/jiahuang/d3-timeline/d3-timeline.js"></script>
+    <script src="{{.BaseURL}}static/krisk/fuse/fuse.min.js"></script>
+    <script src="{{.BaseURL}}static/zeroclipboard/zeroclipboard/ZeroClipboard.min.js"></script>
   </head>
   <body>
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">


### PR DESCRIPTION
This change has all external JS libs that are not currently backed via a CDN (e.g. ones hosted via rawgit.com) served via the [appdash-data](https://github.com/sourcegraph/appdash-data) repository.

This ensures that:

- Appdash loads faster (I've personally seen rawgit.com slow to a halt a few times).
- The web UI does not break when no versions of these libraries are released.

 