### PR TITLE
traceapp: add three different viewing modes to Aggregate View.

### DIFF
--- a/traceapp/aggregate.go
+++ b/traceapp/aggregate.go
@@ -1,6 +1,10 @@
 package traceapp
 
-import "sourcegraph.com/sourcegraph/appdash"
+import (
+	"fmt"
+
+	"sourcegraph.com/sourcegraph/appdash"
+)
 
 // aggItem represents a set of traces with the name (label) and their cumulative
 // time.
@@ -9,29 +13,72 @@ type aggItem struct {
 	Value int64  `json:"value"`
 }
 
+type aggMode int
+
+const (
+	traceOnly aggMode = iota
+	spanOnly
+	traceAndSpan
+)
+
+// parseAggMode parses an aggregation mode:
+//
+//  "trace-only" -> traceOnly
+//  "span-only" -> spanOnly
+//  "trace-and-span" -> traceAndSpan
+//
+func parseAggMode(s string) aggMode {
+	switch s {
+	case "trace-only":
+		return traceOnly
+	case "span-only":
+		return spanOnly
+	case "trace-and-span":
+		return traceAndSpan
+	default:
+		return traceOnly
+	}
+}
+
 // aggregate aggregates and encodes the given traces as JSON to the given writer.
-func (a *App) aggregate(traces []*appdash.Trace) ([]*aggItem, error) {
+func (a *App) aggregate(traces []*appdash.Trace, mode aggMode) ([]*aggItem, error) {
 	aggregated := make(map[string]*aggItem)
+
+	// up updates the aggregated map with the given label and value.
+	up := func(label string, value int64) {
+		// Grab the aggregation item for the named trace, or create a new one if it
+		// does not already exist.
+		i, ok := aggregated[label]
+		if !ok {
+			i = &aggItem{Label: label}
+			aggregated[label] = i
+		}
+
+		// Perform aggregation.
+		i.Value += value
+		if i.Value == 0 {
+			i.Value = 1 // Must be positive values or else d3pie won't render.
+		}
+	}
+
 	for _, trace := range traces {
 		// Calculate the cumulative time -- which we can already get through the
 		// profile view's calculation method.
-		_, prof, err := a.calcProfile(nil, trace)
+		profiles, childProf, err := a.calcProfile(nil, trace)
 		if err != nil {
 			return nil, err
 		}
 
-		// Grab the aggregation item for the named trace, or create a new one if it
-		// does not already exist.
-		i, ok := aggregated[prof.Name]
-		if !ok {
-			i = &aggItem{Label: prof.Name}
-			aggregated[prof.Name] = i
-		}
-
-		// Perform aggregation.
-		i.Value += prof.TimeCum
-		if i.Value == 0 {
-			i.Value = 1 // Must be positive values or else d3pie won't render.
+		if mode == traceOnly {
+			up(childProf.Name, childProf.TimeCum)
+		} else if mode == spanOnly {
+			for _, spanProf := range profiles[1:] {
+				up(spanProf.Name, spanProf.Time)
+			}
+		} else if mode == traceAndSpan {
+			for _, spanProf := range profiles[1:] {
+				up(fmt.Sprintf("%s: %s", childProf.Name, spanProf.Name), spanProf.Time)
+			}
 		}
 	}
 

--- a/traceapp/app.go
+++ b/traceapp/app.go
@@ -189,7 +189,7 @@ func (a *App) serveAggregate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// Perform the aggregation and render the data.
-	aggregated, err := a.aggregate(traces)
+	aggregated, err := a.aggregate(traces, parseAggMode(q.Get("view-mode")))
 	if err != nil {
 		return err
 	}

--- a/traceapp/tmpl/aggregate.html
+++ b/traceapp/tmpl/aggregate.html
@@ -1,12 +1,14 @@
 
 {{define "Title"}}Aggregate View - appdash{{end}}
 {{define "Main"}}
-<h1>Aggregated View</h1>
 
 <style type="text/css">
   html,body {
     /* Disable vertical scrollbar due to canvas being very long. */
     overflow-y: hidden;
+  }
+  #top-right-btns {
+    margin-top: 25px;
   }
   #pieChart {
     width: 800px;
@@ -23,6 +25,20 @@
     top: -100px;
   }
 </style>
+
+<!-- View Mode menu -->
+<div class="btn-group pull-right" role="group" aria-label="..." id="top-right-btns">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" title="choose the aggregated data viewing mode">
+    View Mode <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" role="menu">
+    <li><a href="#" id="view-mode-trace-only" title="aggregate trace root-span names only">Root Spans</a></li>
+    <li><a href="#" id="view-mode-span-only" title="aggregate trace sub-span names only">Sub Spans</a></li>
+    <li><a href="#" id="view-mode-trace-and-span" title="aggregate all trace span names">All Spans</a></li>
+  </ul>
+</div>
+
+<h1>Aggregated View</h1>
 
 <div id="pieChart"></div>
 
@@ -53,10 +69,49 @@
       },
       "data": {
         "sortOrder": "value-desc",
+        "smallSegmentGrouping": {
+          "enabled": true,
+          "value": 1,
+          "valueType": "percentage",
+          "label": "Other (less than 1%)",
+          "color": "#cccccc"
+        },
         "content": data
       }
     });
   });
+
+  // See http://stackoverflow.com/questions/5999118/add-or-update-query-string-parameter
+  function updateQueryStringParameter(uri, key, value) {
+    var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
+    var separator = uri.indexOf('?') !== -1 ? "&" : "?";
+    if (uri.match(re)) {
+      return uri.replace(re, '$1' + key + "=" + value + '$2');
+    }
+    else {
+      return uri + separator + key + "=" + value;
+    }
+  }
+
+  function viewMode(name) {
+    var u = updateQueryStringParameter(window.location.href, "view-mode", name);
+    if (window.location.href != u) {
+      window.location.href = u;
+    }
+  }
+
+  $("#view-mode-trace-only").click(function(e) {
+    e.preventDefault();
+    viewMode("trace-only");
+  })
+  $("#view-mode-span-only").click(function(e) {
+    e.preventDefault();
+    viewMode("span-only");
+  })
+  $("#view-mode-trace-and-span").click(function(e) {
+    e.preventDefault();
+    viewMode("trace-and-span");
+  })
 </script>
 
 {{end}}


### PR DESCRIPTION
This change adds three different viewing modes to the new _Aggregate View_:

- _Root Spans_ - aggregate traces showing root-span names only.
- _Sub Spans_  - aggregate traces showing sub-span names only.
- _All Spans_ - aggregate traces showing all trace span names.

The httptrace package by default names root spans based on the request's
host field (i.e. the host server). This means that Root Spans will show
you the hosts taking up the most time in your system:

---
![default_root_spans](https://cloud.githubusercontent.com/assets/3173176/6975193/7d825e02-d94e-11e4-8752-c975c6b9d175.png)
---

Sub-spans are typically sub-operations in your system, for example SQL
queries or outbound server-side HTTP requests, so Sub Spans view will
show you which sub-operations in your system took the most time:

---
![sub_spans](https://cloud.githubusercontent.com/assets/3173176/6975198/8675b4aa-d94e-11e4-90b0-fd9b8b5b3bed.png)
---

If you're interested in which sub-operations took the most time in each
of your hosts (root traces), then All Spans is a good viewing mode:

---
![all_spans](https://cloud.githubusercontent.com/assets/3173176/6975205/95d4c9ea-d94e-11e4-857b-16ffedb7316c.png)
---

Each mode (as shown above) will trim out sections of the pie chart taking up less than 1% of the time -- depending on the near-equality of your time-spans that may be a lot (as shown above) -- but doesn't affect the primary use: _identifying which take the most time_.

When in doubt for which viewing mode to use, try each  to see which one produces the best
result for your use case.