### PR TITLE
LimitStore (deletes oldest trace when capacity is reached)

### DIFF
--- a/store.go
+++ b/store.go
@@ -386,16 +386,9 @@ type LimitStore struct {
 	// Max is the maximum number of traces that the store should keep.
 	Max int
 
-	// count is the number of traces currently stored. It may never
-	// exceed Max.
-	count int
-
-	// DeleteStoer is the underlying store that spans are saved to and
+	// DeleteStore is the underlying store that spans are saved to and
 	// deleted from.
 	DeleteStore
-
-	// Debug is whether to log debug messages.
-	Debug bool
 
 	mu            sync.Mutex
 	ring          []int64 // ring is a circular list of trace IDs in insertion order.
@@ -414,6 +407,7 @@ func (ls *LimitStore) Collect(id SpanID, anns ...Annotation) error {
 		// Store is at capacity (we know this because the next insert
 		// slot already contains trace); delete oldest.
 		if err := ls.DeleteStore.Delete(ID(ls.ring[ls.nextInsertIdx])); err != nil {
+			ls.mu.Unlock()
 			return err
 		}
 	}

--- a/store.go
+++ b/store.go
@@ -379,3 +379,47 @@ func (rs *RecentStore) evictBefore(t time.Time) {
 		}
 	}()
 }
+
+// A LimitStore wraps another store and deletes the oldest trace when
+// the number of traces reaches the capacity (Max).
+type LimitStore struct {
+	// Max is the maximum number of traces that the store should keep.
+	Max int
+
+	// count is the number of traces currently stored. It may never
+	// exceed Max.
+	count int
+
+	// DeleteStoer is the underlying store that spans are saved to and
+	// deleted from.
+	DeleteStore
+
+	// Debug is whether to log debug messages.
+	Debug bool
+
+	mu            sync.Mutex
+	ring          []int64 // ring is a circular list of trace IDs in insertion order.
+	nextInsertIdx int     // nextInsertIdx is the ring index for the next insertion.
+
+}
+
+// Collect calls the underlying store's Collect, deleting the oldest
+// trace if the capacity has been reached.
+func (ls *LimitStore) Collect(id SpanID, anns ...Annotation) error {
+	ls.mu.Lock()
+	if ls.ring == nil {
+		ls.ring = make([]int64, ls.Max)
+	}
+	if nextInsert := ls.ring[ls.nextInsertIdx]; nextInsert != 0 {
+		// Store is at capacity (we know this because the next insert
+		// slot already contains trace); delete oldest.
+		if err := ls.DeleteStore.Delete(ID(ls.ring[ls.nextInsertIdx])); err != nil {
+			return err
+		}
+	}
+	ls.ring[ls.nextInsertIdx] = int64(id.Trace)
+	ls.nextInsertIdx = (ls.nextInsertIdx + 1) % ls.Max // increment & wrap
+	ls.mu.Unlock()
+
+	return ls.DeleteStore.Collect(id, anns...)
+}

--- a/store_test.go
+++ b/store_test.go
@@ -370,9 +370,10 @@ func TestLimitStore(t *testing.T) {
 
 	traces, _ := ms.Traces()
 	want := []*Trace{
-		{Span: Span{ID: SpanID{3, 4, 5}}},
 		{Span: Span{ID: SpanID{2, 3, 4}}},
+		{Span: Span{ID: SpanID{3, 4, 5}}},
 	}
+	sort.Sort(tracesByIDSpan(traces))
 	if !reflect.DeepEqual(traces, want) {
 		t.Errorf("traces differed\n\ngot traces\n%s\n\nwant traces\n%s", traces, want)
 	}


### PR DESCRIPTION
Similar to RecentStore, but caps memory usage.