### PR TITLE
AggregateStore bug fixes

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -239,7 +239,11 @@ func (as *AggregateStore) Collect(id SpanID, anns ...Annotation) error {
 		nTimes := 0
 		for _, id := range as.groupsByName {
 			g := as.groups[id]
-			nTraces += len(g.Slowest)
+			for _, sm := range g.Slowest {
+				if sm.TraceID != 0 {
+					nTraces++
+				}
+			}
 			nTimes += len(g.Times)
 		}
 

--- a/aggregate.go
+++ b/aggregate.go
@@ -219,6 +219,14 @@ func NewAggregateStore() *AggregateStore {
 // Collect calls the underlying store's Collect, deleting the oldest
 // trace if the capacity has been reached.
 func (as *AggregateStore) Collect(id SpanID, anns ...Annotation) error {
+	// Send collections directly to Keep, as promised.
+	if as.Keep != nil {
+		err := as.Keep.Collect(id, anns...)
+		if err != nil {
+			return err
+		}
+	}
+
 	as.mu.Lock()
 	defer as.mu.Unlock()
 

--- a/aggregate.go
+++ b/aggregate.go
@@ -249,8 +249,13 @@ func (as *AggregateStore) Collect(id SpanID, anns ...Annotation) error {
 		if err != nil {
 			log.Println(err)
 		}
+		exceeding := len(msTraces) - (len(as.groupsByName) * as.NSlowest)
+		if exceeding < 0 {
+			exceeding = 0
+		}
+		nextEvict := as.MinEvictAge - time.Since(as.lastEvicted)
 		log.Printf("AggregateStore: [%d groups by ID] [%d groups by name] [%d-slowest traces] [%d trace times]\n", len(as.groups), len(as.groupsByName), nTraces, nTimes)
-		log.Printf("AggregateStore: [%d traces in MemoryStore; exceeding us by %d] [eviction in %s]\n", len(msTraces), len(msTraces)-nTraces, as.MinEvictAge-time.Since(as.lastEvicted))
+		log.Printf("AggregateStore: [%d traces in MemoryStore; exceeding us by %d] [eviction in %s]\n", len(msTraces), exceeding, nextEvict)
 
 		// Validate that the N-slowest traces we store are not exceeding what the user asked for.
 		if nTraces > 0 && (len(as.groupsByName)/nTraces) > as.NSlowest {

--- a/aggregate.go
+++ b/aggregate.go
@@ -471,7 +471,7 @@ func (as *AggregateStore) evictBefore(t time.Time) error {
 			}
 		}
 
-		// If the group is not complete empty, we have nothing more to do.
+		// If the group is not completely empty, we have nothing more to do.
 		if len(group.Times) > 0 || len(group.Slowest) > 0 {
 			continue
 		}


### PR DESCRIPTION
See each commit message for details, overview:

- Add AggregateStore statistics for debugging memory leaks.
- Fix a minor comment typo.
- Properly send collections to AggregateStore.Keep as it promises to.
- Use a workaround to avoid leaking memory in AggregateStore.