### PR TITLE
Fix LimitStore so multiple collections don't evict traces early.

### DIFF
--- a/store.go
+++ b/store.go
@@ -420,10 +420,6 @@ func (ls *LimitStore) Collect(id SpanID, anns ...Annotation) error {
 	// Check if the trace already exists in the ring. Otherwise, we would evict
 	// an old trace upon each annotation collection, rather than upon each new
 	// trace.
-	ids := make([]ID, 0)
-	for _, x := range ls.ring {
-		ids = append(ids, ID(x))
-	}
 	if _, ok := ls.traces[id.Trace]; ok {
 		ls.mu.Unlock()
 		return ls.DeleteStore.Collect(id, anns...)

--- a/store.go
+++ b/store.go
@@ -399,7 +399,7 @@ type LimitStore struct {
 	DeleteStore
 
 	mu            sync.Mutex
-	traces        map[ID]struct{} // map of traces to quickly determine which traces exist in ring already.
+	traces        map[ID]struct{} // set of traces to quickly determine which traces exist in ring already.
 	ring          []int64         // ring is a circular list of trace IDs in insertion order.
 	nextInsertIdx int             // nextInsertIdx is the ring index for the next insertion.
 

--- a/store_test.go
+++ b/store_test.go
@@ -363,6 +363,7 @@ func TestLimitStore(t *testing.T) {
 	}
 
 	rs.MustCollect(SpanID{3, 4, 5})
+	rs.MustCollect(SpanID{3, 5, 6})
 
 	if traces, _ := ms.Traces(); len(traces) != 2 {
 		t.Errorf("got traces %v, want %d total", traces, 2)
@@ -371,7 +372,12 @@ func TestLimitStore(t *testing.T) {
 	traces, _ := ms.Traces()
 	want := []*Trace{
 		{Span: Span{ID: SpanID{2, 3, 4}}},
-		{Span: Span{ID: SpanID{3, 4, 5}}},
+		{
+			Span: Span{ID: SpanID{3, 5, 6}},
+			Sub: []*Trace{
+				{Span: Span{ID: SpanID{3, 4, 5}}},
+			},
+		},
 	}
 	sort.Sort(tracesByIDSpan(traces))
 	if !reflect.DeepEqual(traces, want) {


### PR DESCRIPTION
This change adds a test (failing before and passing after this change) regarding a serious bug in `LimitStore` where it would treat each individual collection as the beginning of a new trace (i.e., evicting an "old" trace even though the "new" one is already inside the `LimitStore`!).