### PR TITLE
Improve performance of AggregateStore and ChunkedCollector

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -50,24 +50,24 @@ func TestAggregateStore(t *testing.T) {
 	}
 
 	// Verify we have the aggregated trace events.
-	var agg []AggregateEvent
+	var agg *AggregateEvent
 	for _, tr := range traces {
-		evs, err := tr.Aggregated()
+		ev, _, err := tr.Aggregated()
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(evs) > 0 {
-			agg = evs
+		if ev != nil {
+			agg = ev
 		}
 	}
-	if len(agg) != 1 {
-		t.Fatalf("expected 1 aggregated trace event, found %d", len(agg))
+	if agg == nil {
+		t.Fatalf("expected 1 aggregated trace event, found nil")
 	}
 
 	// Verify we have the N-slowest other full traces.
 	var found []ID
 	for _, t := range traces {
-		for _, want := range agg[0].Slowest {
+		for _, want := range agg.Slowest {
 			if t.Span.ID.Trace == want {
 				found = append(found, want)
 			}
@@ -121,23 +121,23 @@ func TestAggregateStoreNSlowest(t *testing.T) {
 		}
 
 		// Verify we have the aggregated trace events.
-		var agg []AggregateEvent
+		var agg *AggregateEvent
 		for _, tr := range traces {
-			evs, err := tr.Aggregated()
+			ev, _, err := tr.Aggregated()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(evs) > 0 {
-				agg = evs
+			if ev != nil {
+				agg = ev
 			}
 		}
-		if len(agg) != 1 {
-			t.Fatalf("expected 1 aggregated trace event, found %d", len(agg))
+		if agg == nil {
+			t.Fatalf("expected 1 aggregated trace event, found nil")
 		}
 
 		// Determine time of each slowest trace.
 		var d []time.Duration
-		for _, slowest := range agg[0].Slowest {
+		for _, slowest := range agg.Slowest {
 			st, err := ms.Trace(slowest)
 			if err != nil {
 				t.Fatal(err)

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -11,20 +11,6 @@ var _ = EventMarshaler(AggregateEvent{})
 var _ = EventUnmarshaler(AggregateEvent{})
 var _ = Event(AggregateEvent{})
 
-// fakeTimespan represents a fake timespan event, and is used for the tests
-// below.
-type fakeTimespan struct {
-	S, E time.Time
-}
-
-func (f fakeTimespan) Schema() string   { return "fake" }
-func (f fakeTimespan) Start() time.Time { return f.S }
-func (f fakeTimespan) End() time.Time   { return f.E }
-
-var _ = TimespanEvent(fakeTimespan{})
-
-func init() { RegisterEvent(fakeTimespan{}) }
-
 // TestAggregateStore tests basic AggregateStore functionality.
 func TestAggregateStore(t *testing.T) {
 	// Create an aggregate store.
@@ -41,7 +27,7 @@ func TestAggregateStore(t *testing.T) {
 		root := NewRootSpanID()
 		rec := NewRecorder(root, as)
 		rec.Name("the-trace-name")
-		e := fakeTimespan{
+		e := timespanEvent{
 			S: time.Now().Add(time.Duration(-i) * time.Minute),
 			E: time.Now(),
 		}
@@ -112,7 +98,7 @@ func TestAggregateStoreNSlowest(t *testing.T) {
 			root := NewRootSpanID()
 			rec := NewRecorder(root, as)
 			rec.Name("the-trace-name")
-			e := fakeTimespan{
+			e := timespanEvent{
 				S: now,
 				E: now.Add(times[i]),
 			}
@@ -227,7 +213,7 @@ func TestAggregateStoreMinEvictAge(t *testing.T) {
 		root := NewRootSpanID()
 		rec := NewRecorder(root, as)
 		rec.Name("the-trace-name")
-		e := fakeTimespan{
+		e := timespanEvent{
 			S: time.Now().Add(time.Duration(-i) * time.Minute),
 			E: time.Now(),
 		}

--- a/collector_test.go
+++ b/collector_test.go
@@ -260,11 +260,19 @@ func BenchmarkChunkedCollector500(b *testing.B) {
 		}),
 		MinInterval: time.Millisecond * 10,
 	}
+	const(
+		nCollections = 500
+		nAnnotations = 50
+	)
 	var x ID
 	for i := 0; i < b.N; i++ {
-		for c := 0; c < 500; c++ {
+		for c := 0; c < nCollections; c++ {
+			anns := make([]Annotation, nAnnotations)
+			for i := range anns {
+				anns[i] = Annotation{Key: "k", Value: []byte{'v'}}
+			}
 			x++
-			err := cc.Collect(SpanID{x, x + 1, x + 2})
+			err := cc.Collect(SpanID{x, x + 1, x + 2}, anns...)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/collector_test.go
+++ b/collector_test.go
@@ -121,7 +121,7 @@ func TestCollectorServer_stress(t *testing.T) {
 func BenchmarkRemoteCollector1000(b *testing.B) {
 	const (
 		nCollections = 1000
-		nAnnotations = 1000
+		nAnnotations = 100
 	)
 
 	l, err := net.Listen("tcp", ":0")

--- a/event.go
+++ b/event.go
@@ -125,6 +125,7 @@ func init() {
 	RegisterEvent(spanName{})
 	RegisterEvent(logEvent{})
 	RegisterEvent(msgEvent{})
+	RegisterEvent(timespanEvent{})
 }
 
 // UnmarshalEvents unmarshals all events found in anns into
@@ -168,6 +169,15 @@ type TimespanEvent interface {
 	Start() time.Time
 	End() time.Time
 }
+
+// timespanEvent implements the TimespanEvent interface.
+type timespanEvent struct {
+	S, E time.Time
+}
+
+func (timespanEvent) Schema() string      { return "timespan" }
+func (ev timespanEvent) Start() time.Time { return ev.S }
+func (ev timespanEvent) End() time.Time   { return ev.E }
 
 // A TimestampedEvent is an Event with a timestamp.
 type TimestampedEvent interface {

--- a/multi.go
+++ b/multi.go
@@ -1,0 +1,82 @@
+package appdash
+
+// multiStore is like a normal store except all operations occur on the multiple
+// underlying stores.
+type multiStore struct {
+	// stores is the underlying set of stores that operations take place on.
+	stores []Store
+}
+
+// Collect implements the Collector interface by invoking Collect on each
+// underlying store, returning the first error that occurs.
+func (ms *multiStore) Collect(id SpanID, anns ...Annotation) error {
+	for _, s := range ms.stores {
+		if err := s.Collect(id, anns...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Trace implements the Store interface by returning the first trace found by
+// asking each underlying store for it in consecutive order.
+func (ms *multiStore) Trace(t ID) (*Trace, error) {
+	for _, s := range ms.stores {
+		trace, err := s.Trace(t)
+		if err == ErrTraceNotFound {
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+		return trace, nil
+	}
+	return nil, ErrTraceNotFound
+}
+
+// MultiStore returns a Store whose operations occur on the multiple given
+// stores.
+func MultiStore(s ...Store) Store {
+	return &multiStore{
+		stores: s,
+	}
+}
+
+// multiStore is like a normal queryer except it queries from multiple
+// underlying stores.
+type multiQueryer struct {
+	// queryers is the underlying set of queryers that operations take place on.
+	queryers []Queryer
+}
+
+// Traces implements the Queryer interface by returning the union of all
+// underlying stores.
+//
+// It panics if any underlying store does not implement the appdash Queryer
+// interface.
+func (mq *multiQueryer) Traces() ([]*Trace, error) {
+	var (
+		union = make(map[ID]struct{})
+		all   []*Trace
+	)
+	for _, q := range mq.queryers {
+		traces, err := q.Traces()
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range traces {
+			if _, ok := union[t.ID.Trace]; !ok {
+				union[t.ID.Trace] = struct{}{}
+				all = append(all, t)
+			}
+		}
+	}
+	return all, nil
+}
+
+// MultiQueryer returns a Queryer whose Traces method returns a union of all
+// traces across each queryer.
+func MultiQueryer(q ...Queryer) Queryer {
+	return &multiQueryer{
+		queryers: q,
+	}
+}

--- a/store_test.go
+++ b/store_test.go
@@ -502,15 +502,23 @@ func BenchmarkMemoryStoreReadFrom1000(b *testing.B) {
 }
 
 func BenchmarkRecentStore500(b *testing.B) {
+	const (
+		nCollections = 500
+		nAnnotations = 100
+	)
 	rs := &RecentStore{
 		DeleteStore: NewMemoryStore(),
 		MinEvictAge: 20 * time.Second,
 	}
 	var x ID
 	for i := 0; i < b.N; i++ {
-		for c := 0; c < 500; c++ {
+		for c := 0; c < nCollections; c++ {
 			x++
-			err := rs.Collect(SpanID{x, 2, 3})
+			anns := make([]Annotation, nAnnotations)
+			for a := range anns {
+				anns[a] = Annotation{"k1", []byte("v1")}
+			}
+			err := rs.Collect(SpanID{x, 2, 3}, anns...)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/store_test.go
+++ b/store_test.go
@@ -525,3 +525,28 @@ func BenchmarkRecentStore500(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkLimitStore500(b *testing.B) {
+	const (
+		nCollections = 500
+		nAnnotations = 100
+	)
+	rs := &LimitStore{
+		DeleteStore: NewMemoryStore(),
+		Max:         2000,
+	}
+	var x ID
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < nCollections; c++ {
+			x++
+			anns := make([]Annotation, nAnnotations)
+			for a := range anns {
+				anns[a] = Annotation{"k1", []byte("v1")}
+			}
+			err := rs.Collect(SpanID{x, 2, 3}, anns...)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Make `ChunkedCollector` more efficient and allocate less memory.
- Significantly lessen memory consumption of apps making use of `AggregateStore`.
- Add several new benchmarks and a few tests.
