### PR TITLE
Improve ChunkedCollector performance slightly

### DIFF
--- a/collector_danger_test.go
+++ b/collector_danger_test.go
@@ -1,0 +1,85 @@
+// +build danger
+
+// Run with:
+//
+//  go test -tags=danger -memprofilerate=1 -memprofile=mem.out -bench=BenchmarkChunkedCollector1mil -run=NONE -v
+//
+// (danger tag is because it is very slow and eats a lot of memory!)
+
+package appdash
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"testing"
+	"time"
+)
+
+// BenchmarkChunkedCollector1mil performs 1 million collects with the same set
+// of annotations and prints several runtime memory statistics during the
+// process, invoking runtime.GC and runtime/debug.FreeOSMemory ten times as the
+// final step.
+func BenchmarkChunkedCollector1mil(b *testing.B) {
+	cc := &ChunkedCollector{
+		Collector: collectorFunc(func(span SpanID, anns ...Annotation) error {
+			return nil
+		}),
+		MinInterval: time.Millisecond * 1,
+	}
+	const (
+		nCollections = 1000000
+		nAnnotations = 50
+	)
+	anns := make([]Annotation, nAnnotations)
+	for i := range anns {
+		anns[i] = Annotation{Key: "k", Value: []byte{'v'}}
+	}
+
+	memStats := &memStats{
+		Collections: nCollections,
+	}
+
+	memStats.Log("pre")
+	var x ID
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < nCollections; c++ {
+			x++
+			err := cc.Collect(SpanID{x, x + 1, x + 2}, anns...)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	memStats.Log("post")
+
+	// Perform N garbage collections (multiple are needed because the GC can at
+	// times need two phases to collect everything, we use an overly large
+	// amount just to be sure).
+	fmt.Println("[garbage collections]")
+	nGC := 10
+	for i := 0; i < nGC; i++ {
+		start := time.Now()
+		runtime.GC()
+		fmt.Printf("  %v. GC - %v\n", i, time.Since(start))
+	}
+	fmt.Println("")
+	memStats.Log("after GC")
+
+	// Perform N debug.FreeOSMemory() calls, again performing multiple just to
+	// besure.
+	fmt.Println("[free os memory]")
+	nFree := 10
+	for i := 0; i < nFree; i++ {
+		start := time.Now()
+		debug.FreeOSMemory()
+		fmt.Printf("  %v. FreeOSMemory - %v\n", i, time.Since(start))
+	}
+	fmt.Println("")
+	memStats.Log("after GC & FreeOSMemory")
+
+	fmt.Printf("sleeping 30s; check memory usage with 'top -p %v' now", os.Getpid())
+	time.Sleep(30 * time.Second)
+}

--- a/memstats.go
+++ b/memstats.go
@@ -1,0 +1,141 @@
+package appdash
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// memStats collects and prints some formatted *runtime.MemStats fields.
+type memStats struct {
+	// Number of collections occuring.
+	Collections int
+
+	indent int
+}
+
+// fmtBytes returns b (in bytes) as a nice human readable string.
+func (m *memStats) fmtBytes(b uint64) string {
+	var (
+		kb uint64 = 1024
+		mb uint64 = kb * 1024
+		gb uint64 = mb * 1024
+	)
+	if b < kb {
+		return fmt.Sprintf("%dB", b)
+	}
+	if b < mb {
+		return fmt.Sprintf("%dKB", b/kb)
+	}
+	if b < gb {
+		return fmt.Sprintf("%dMB", b/mb)
+	}
+	return fmt.Sprintf("%dGB", b/gb)
+}
+
+// repeat returns s repeated N times consecutively.
+func (m *memStats) repeat(s string, n int) string {
+	var v string
+	for i := 0; i < n; i++ {
+		v += s
+	}
+	return v
+}
+
+// logf invokes fmt.Printf but with m.indent spaces prefixed.
+func (m *memStats) logf(format string, args ...interface{}) {
+	fmt.Printf("%s%s", m.repeat(" ", m.indent), fmt.Sprintf(format, args...))
+}
+
+// logColumns logs the given rows as formatted (properly indented) columns.
+func (m *memStats) logColumns(rows ...[]interface{}) {
+	columnWidths := make([]int, len(rows[0]))
+	for column := range rows[0] {
+		for row := 0; row < len(rows); row++ {
+			w := len(fmt.Sprintf("%v", rows[row][column]))
+			if w > columnWidths[column] {
+				columnWidths[column] = w
+			}
+		}
+	}
+
+	for _, row := range rows {
+		m.logf("- ")
+		for c, column := range row {
+			w := len(fmt.Sprintf("%v", column))
+			fmt.Printf("%v  %s", column, m.repeat(" ", columnWidths[c]-w))
+		}
+		fmt.Printf("\n")
+	}
+}
+
+// Log should be called with a human-readable segment name (i.e. the segment of
+// code whose memory perf is being tested).
+func (m *memStats) Log(segment string) {
+	var s runtime.MemStats
+	runtime.ReadMemStats(&s)
+	m.logf("\n\n[%s] %d-collections:\n", segment, m.Collections)
+	m.indent += 2
+
+	m.logf("General statistics\n")
+	m.indent += 2
+	m.logColumns(
+		[]interface{}{"Alloc", m.fmtBytes(s.Alloc), "(allocated and still in use)"},
+		[]interface{}{"TotalAlloc", m.fmtBytes(s.TotalAlloc), "(allocated (even if freed))"},
+		[]interface{}{"Sys", m.fmtBytes(s.Sys), "(obtained from system (sum of XxxSys below))"},
+		[]interface{}{"Lookups", s.Lookups, "(number of pointer lookups)"},
+		[]interface{}{"Mallocs", s.Mallocs, "(number of mallocs)"},
+		[]interface{}{"Frees", s.Frees, "(number of frees)"},
+	)
+	m.indent -= 2
+	fmt.Printf("\n")
+
+	m.logf("Main allocation heap statistics\n")
+	m.indent += 2
+	m.logColumns(
+		[]interface{}{"HeapAlloc", m.fmtBytes(s.HeapAlloc), "(allocated and still in use)"},
+		[]interface{}{"HeapSys", m.fmtBytes(s.HeapSys), "(obtained from system)"},
+		[]interface{}{"HeapIdle", m.fmtBytes(s.HeapIdle), "(in idle spans)"},
+		[]interface{}{"HeapInuse", m.fmtBytes(s.HeapInuse), "(in non-idle span)"},
+		[]interface{}{"HeapReleased", m.fmtBytes(s.HeapReleased), "(released to the OS)"},
+		[]interface{}{"HeapObjects", s.HeapObjects, "(total number of allocated objects)"},
+	)
+	m.indent -= 2
+	fmt.Printf("\n")
+
+	m.logf("Low-level fixed-size structure allocator statistics\n")
+	m.indent += 2
+	m.logColumns(
+		[]interface{}{"StackInuse", m.fmtBytes(s.StackInuse), "(used by stack allocator right now)"},
+		[]interface{}{"StackSys", m.fmtBytes(s.StackSys), "(obtained from system)"},
+		[]interface{}{"MSpanInuse", m.fmtBytes(s.MSpanInuse), "(mspan structures / in use now)"},
+		[]interface{}{"MSpanSys", m.fmtBytes(s.MSpanSys), "(obtained from system)"},
+		[]interface{}{"MCacheInuse", m.fmtBytes(s.MCacheInuse), "(in use now))"},
+		[]interface{}{"MCacheSys", m.fmtBytes(s.MCacheSys), "(mcache structures / obtained from system)"},
+		[]interface{}{"BuckHashSys", m.fmtBytes(s.BuckHashSys), "(profiling bucket hash table / obtained from system)"},
+		[]interface{}{"GCSys", m.fmtBytes(s.GCSys), "(GC metadata / obtained form system)"},
+		[]interface{}{"OtherSys", m.fmtBytes(s.OtherSys), "(other system allocations)"},
+	)
+	fmt.Printf("\n")
+	m.indent -= 2
+
+	// TODO(slimsag): remaining GC fields may be useful later:
+	/*
+	   // Garbage collector statistics.
+	   NextGC       uint64 // next collection will happen when HeapAlloc ≥ this amount
+	   LastGC       uint64 // end time of last collection (nanoseconds since 1970)
+	   PauseTotalNs uint64
+	   PauseNs      [256]uint64 // circular buffer of recent GC pause durations, most recent at [(NumGC+255)%256]
+	   PauseEnd     [256]uint64 // circular buffer of recent GC pause end times
+	   NumGC        uint32
+	   EnableGC     bool
+	   DebugGC      bool
+
+	   // Per-size allocation statistics.
+	   // 61 is NumSizeClasses in the C code.
+	   BySize [61]struct {
+	           Size    uint32
+	           Mallocs uint64
+	           Frees   uint64
+	   }
+	*/
+}


### PR DESCRIPTION
# Summary

This change improves performance of `ChunkedCollector` slightly, but also highlights an important issue (which I strongly believe will improve in Go 1.5, hopefully I will have time to test with 1.5 soon to verify). For now see the workaround mentioned in [Solution](#Solution) section 2.

(also see relevant tests and data at [Appdash PR #80](https://github.com/sourcegraph/appdash/pull/80))

### Presumptions

I believe that `ChunkedCollector` when placing items into it's underlying map (which holds onto them for < 500ms in our prod. apps, and just 10ms in our tests) is indirectly causing 20-41k tiny heap objects to be allocated (but the Go code is NOT leaking them) and that the Go runtime is poorly equipped in Go 1.4 to either: 

1. Reuse these small objects behind the map so that many allocations do not need to occur.
2. Release the memory allocated by these small objects back to the OS (seen as `top RES` above).

### History

I have also observed results similiar to this before in another project of mine (which unlike the case here, actually allocated several hundred thousand small objects per second), leaving me with ~12ms GC times on average. I believe these issues to be one in the same and likely fixed or improved significantly with the Go 1.5 GC improvements.

### Analysis:

- [Tests 3](https://github.com/sourcegraph/appdash/pull/80#issuecomment-128191959) [and 4](https://github.com/sourcegraph/appdash/pull/80#issuecomment-128192006) show that garbage collection does bring the number of heap-objects back down to a reasonable amount, but still worse than it should be (none of those objects are in use!).
- [Test 1](https://github.com/sourcegraph/appdash/pull/80#issuecomment-128191822) shows that invoking both `GC` and `FreeOSMemory` brings the number of heap-objects back to the lowest numbers (i.e. what they should be). 
- Only [test 1](https://github.com/sourcegraph/appdash/pull/80#issuecomment-128191822) (which invokes `FreeOSMemory`) appears to release any memory back to the host OS (Note: it is likely that Go invokes this function periodically and our test just doesn't run long enough to hit this, but I am not certain).

### Solution:

In order to fix this issue i have looked at two things as a solution:

1. Attempt to lower the amount of heap objects that Appdash `ChunkedCollector` must allocate.
  - This is not possible, because (after PR #80 is merged) it is literally just a very simple map and is being cleared to nil upon each `ChunkedCollector.Flush`.
  - Using anything other than a map (e.g. a slice) is probably not viable because of the number of spans that will end up in the map, we would effectively be trading memory usage for CPU usage. Not good.
  - However, I was able to identify and remove (in PR #80) a single slice that was uneeded, this cuts the total allocations nearly in half.
2. Setup a background goroutine that occasionally invokes `runtime.GC` twice (needed to trigger a full GC) followed by one `FreeOSMemory` call.
  - Go by default triggers a GC only after the heap has grown 100%, which is normally fine, but in this case it appears to be unable to recollect these small objects and reuse them, so the heap grows nearly unbounded in size.
  - It is likely this issue would appear in apps today as a unbounded heap growth up to entire memory consumption, followed by either a (very) long GC or an OOM runtime panic.
  - A good value for which people may call these three functions in sequence might be every 5-30 minutes, just enough so that these small allocations are returned to the host OS (and can be reqaquired by Go subsequently) before the heap grows too large, but not such a quick value that it would hinder performance.

Example:

```
func init() {
	// Workaround until Go 1.5 is released, as described at:
	//
	//  https://github.com/sourcegraph/appdash/pull/80
	//
	go func() {
		for{
			time.Sleep(5 * time.Minute)
			runtime.GC()
			runtime.GC()
			debug.FreeOSMemory()
		}
	}()
}
```