### PR TITLE
traceapp: Use http.FileSystem generated by vfsgen.

### DIFF
--- a/traceapp/app.go
+++ b/traceapp/app.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/mux"
 
 	"sourcegraph.com/sourcegraph/appdash"
@@ -63,11 +62,7 @@ func New(r *Router) *App {
 	r.r.Get(AggregateRoute).Handler(handlerFunc(app.serveAggregate))
 
 	// Static file serving.
-	r.r.Get(StaticRoute).Handler(http.StripPrefix("/static/", http.FileServer(&assetfs.AssetFS{
-		Asset:    static.Asset,
-		AssetDir: static.AssetDir,
-		Prefix:   "",
-	})))
+	r.r.Get(StaticRoute).Handler(http.StripPrefix("/static/", http.FileServer(static.Data)))
 
 	return app
 }


### PR DESCRIPTION
This change switches `traceapp` to use the `http.FileSystem` generated directly by `vfsgen`.

## Rationale

Reasons for switching to `vfsgen` include:

- Consistency across all Sourcegraph code bases.
   - Other projects _need_ vfsgen for its additional functionality, and it's good to use the same tool for this task.
- Ability to easily enable gzipped compression efficiently in the future.
- No need for a follow-up `go fmt ./...` after regeneration.
- Usage of `http.FileSystem` directly matches the needs of this project (bonus of being done in one package instead of across two separately maintained packages).

Note: This change should be merged at the same time as sourcegraph/appdash-data#5, because they depend on each other.