### PR TITLE
Improve ui

### DIFF
--- a/httptrace/client.go
+++ b/httptrace/client.go
@@ -140,7 +140,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	child := t.Recorder.Child()
 	if t.SetName {
-		child.Name(req.URL.Host)
+		child.Name(req.URL.Host + req.URL.Path)
 	}
 	SetSpanIDHeader(req.Header, child.SpanID)
 

--- a/httptrace/server.go
+++ b/httptrace/server.go
@@ -100,7 +100,7 @@ func Middleware(c appdash.Collector, conf *MiddlewareConfig) func(rw http.Respon
 		if e.Route != "" {
 			rec.Name(e.Route)
 		} else {
-			rec.Name(e.Request.Host)
+			rec.Name(r.URL.Host + r.URL.Path)
 		}
 		rec.Event(e)
 	}

--- a/traceapp/tmpl/data/trace.html
+++ b/traceapp/tmpl/data/trace.html
@@ -1,6 +1,10 @@
 {{define "Title"}}{{if .Trace.ID.Parent}}span {{.Trace.ID.Span}} - {{end}} trace {{.Trace.ID.Trace}} - appdash{{end}}
 
 {{define "Main"}}
+
+<script src="{{.BaseURL}}static/Caged/d3-tip/index.js"></script>
+<link rel="stylesheet" href="{{.BaseURL}}static/Caged/d3-tip/example-styles.css">
+
 <style>
   #copy-json:hover {
     cursor: pointer;
@@ -349,11 +353,21 @@
         return;
       }
 
-      var timespanHover = function(chart, index) {
-        var div = $('#hoverRes');
-        var colors = chart.colors();
-        div.find('.coloredDiv').css('background-color', colors(index));
-        div.find('#name').text(visibleData[index].label);
+      var hoverTooltip = null;
+
+      var timespanHover = function(within, chart, index) {
+        if(within) {
+          var div = $('#hoverRes');
+          var colors = chart.colors();
+          div.find('.coloredDiv').css('background-color', colors(index));
+          div.find('#name').text(visibleData[index].fullLabel);
+          div.find('#name').attr("title", visibleData[index].label);
+
+          tip.html(visibleData[index].fullLabel);
+          tip.show(this, $("#timelineItem_"+index)[0]);
+        } else {
+          tip.hide();
+        }
       }
 
       // Initialize the timeline chart.
@@ -361,13 +375,20 @@
                     .width(width)
                     .stack()
                     .margin({left:em(6), right:0, top:0, bottom:0})
-                    .hover(function (d, i, datum) { timespanHover(chart, i) })
+                    .hover(function (d, i, datum) { timespanHover(true, chart, i) })
+                    .mouseout(function (d, i, datum) { timespanHover(false, chart, i) })
                     .click(function (d, i, datum) {
                       window.location.href = datum.url;
                       //alert(JSON.stringify(datum.rawData, null, 2));
                     });
+
+      // Initialize tooltip
+      var tip = d3.tip().attr('class', 'd3-tip');
+      tip.offset([-10, 0]);
+
       var svg = d3.select(".trace-timeline").append("svg").attr("width", width)
-                  .datum(visibleData).call(chart);
+                  .datum(visibleData).call(chart)
+                  .call(tip);
 
       // Make text on each timeline element click-able. d3-timeline.js doesn't
       // seem to have a way to support this easily.
@@ -378,12 +399,15 @@
       // The last number of that is the index into our visibleData.
       $(".trace-timeline g>text").each(function() {
         var index = numFromEnd($(this).prev().attr('id'));
-        $(this).hover(function() {
-          timespanHover(chart, index);
-        });
-        $(this).click(function() {
-          window.location.href = visibleData[index].url;
-        });
+
+        d3.select(this)
+          .on("mouseover", function() {
+            timespanHover(true, chart, index);
+          })
+          .on("mouseout", function() { timespanHover(false, chart, index); })
+          .on("click", function() {
+            window.location.href = visibleData[index].url;
+          });
 
         // When there is a contextmenu (e.g. right click) event we open the
         // context menu on the timespan rectangle.

--- a/traceapp/vis.go
+++ b/traceapp/vis.go
@@ -15,6 +15,7 @@ import (
 
 type timelineItem struct {
 	Label        string                  `json:"label"`
+	FullLabel    string                  `json:"fullLabel"`
 	Times        []*timelineItemTimespan `json:"times"`
 	Data         map[string]string       `json:"rawData"`
 	SpanID       string                  `json:"spanID"`
@@ -56,11 +57,17 @@ func (a *App) d3timelineInner(t *appdash.Trace, depth int) ([]timelineItem, erro
 		}
 	}
 
+	name := t.Span.Name()
+	if len(name) > 13 {
+		name = name[:13]
+		name += "…"
+	}
 	item := timelineItem{
-		Label:  t.Span.Name(),
-		Data:   t.Annotations.StringMap(),
-		SpanID: t.Span.ID.Span.String(),
-		URL:    u.String(),
+		Label:     name,
+		FullLabel: t.Span.Name(),
+		Data:      t.Annotations.StringMap(),
+		SpanID:    t.Span.ID.Span.String(),
+		URL:       u.String(),
 	}
 	if t.Span.ID.Parent != 0 {
 		item.ParentSpanID = t.Span.ID.Parent.String()


### PR DESCRIPTION
- Default to using hostname _plus_ URL path, since this reflect what most users will want in the general case (note they can always set their own name, of course).
- Cut off really long span names (>14 characters) to avoid overlapping contents (limitation of d3-timeline).
- To show the full span name, just hover over it (a _very snappy_ tooltip will appear).
- Depends on https://github.com/sourcegraph/appdash-data/pull/7

Before:

----------------------------------------
![image](https://cloud.githubusercontent.com/assets/3173176/10293849/b53ca79e-6b6b-11e5-8bb0-66ba31dd2a76.png)
----------------------------------------

After:

----------------------------------------
![image](https://cloud.githubusercontent.com/assets/3173176/10293770/30f6e1f2-6b6b-11e5-8db5-4db59c3720ee.png)
----------------------------------------
