### PR TITLE
httptrace: Collect Name & User after inner handler

### DIFF
--- a/httptrace/server.go
+++ b/httptrace/server.go
@@ -79,12 +79,6 @@ func Middleware(c appdash.Collector, conf *MiddlewareConfig) func(rw http.Respon
 
 		e := NewServerEvent(r)
 		e.ServerRecv = time.Now()
-		if conf.RouteName != nil {
-			e.Route = conf.RouteName(r)
-		}
-		if conf.CurrentUser != nil {
-			e.User = conf.CurrentUser(r)
-		}
 
 		rr := &responseInfoRecorder{ResponseWriter: rw}
 		next(rr, r)
@@ -92,6 +86,12 @@ func Middleware(c appdash.Collector, conf *MiddlewareConfig) func(rw http.Respon
 
 		if !usingProvidedSpanID {
 			e.Request = requestInfo(r)
+		}
+		if conf.RouteName != nil {
+			e.Route = conf.RouteName(r)
+		}
+		if conf.CurrentUser != nil {
+			e.User = conf.CurrentUser(r)
 		}
 		e.Response = responseInfo(rr.partialResponse())
 		e.ServerSend = time.Now()


### PR DESCRIPTION
This allows inner handlers to run and set information which the MiddlewareConfig
may want to use. A concrete example of this is having the middleware run before
mux has had a chance to set a route name.

This could potentially break existing uses if the inner handlers destroy or
mutate the information that MiddlewareConfig depended on.