### PR TITLE
Added timeout feature for httptrace.Transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Most explicit routing to GCE Precise
+sudo: required
+dist: precise
 language: go
 go:
  - 1.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-# Most explicit routing to GCE Precise
-sudo: required
-dist: precise
+# Container-based Precise due to `sudo: false`
+sudo: false
 language: go
 go:
  - 1.4


### PR DESCRIPTION
This PR enables `httptrace.Transport` to use timeout parameter and cancel request.
