### PR TITLE
Show overflow label on trace view

### DIFF
--- a/traceapp/tmpl/data/trace.html
+++ b/traceapp/tmpl/data/trace.html
@@ -388,7 +388,14 @@
 
       var svg = d3.select(".trace-timeline").append("svg").attr("width", width)
                   .datum(visibleData).call(chart)
+                  .style("overflow", "visible")
                   .call(tip);
+
+      var filter = function(text){
+        if (text.length < 14) { return text; }
+        return text.substr(0, 13) + "...";
+      };
+      var $labels = $(".trace-timeline text.timeline-label");
 
       // Make text on each timeline element click-able. d3-timeline.js doesn't
       // seem to have a way to support this easily.
@@ -399,6 +406,7 @@
       // The last number of that is the index into our visibleData.
       $(".trace-timeline g>text").each(function() {
         var index = numFromEnd($(this).prev().attr('id'));
+        var label = $labels[index];
 
         d3.select(this)
           .on("mouseover", function() {
@@ -409,10 +417,15 @@
             window.location.href = visibleData[index].url;
           });
 
+        d3.select(label)
+          .on("mouseover", function() { timespanHover(true, chart, index); })
+          .on("mouseout", function() { timespanHover(false, chart, index); })
+          .text(filter(label.innerHTML))
+
         // When there is a contextmenu (e.g. right click) event we open the
         // context menu on the timespan rectangle.
         var datum = d3.select($(this).prev()[0]).data()[0];
-        $(this).on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
+        $([this, label]).on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
         $(this).prev().on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
       });
     }

--- a/traceapp/vis.go
+++ b/traceapp/vis.go
@@ -57,13 +57,8 @@ func (a *App) d3timelineInner(t *appdash.Trace, depth int) ([]timelineItem, erro
 		}
 	}
 
-	name := t.Span.Name()
-	if len(name) > 13 {
-		name = name[:13]
-		name += "…"
-	}
 	item := timelineItem{
-		Label:     name,
+		Label:     t.Span.Name(),
 		FullLabel: t.Span.Name(),
 		Data:      t.Annotations.StringMap(),
 		SpanID:    t.Span.ID.Span.String(),


### PR DESCRIPTION
This PR improve trace view UI.

1. show full text on each timeline
2. show overflowed text on the edge of the right side data
3. left side has same feature as timeline data
    - show tooltip when hovered
    - show context menu when right click



![screenshot 2016-01-14 15 20 55](https://cloud.githubusercontent.com/assets/2827521/12317420/81f7687a-bad4-11e5-8791-2660b9e21f82.png)
