### PR TITLE
Improves TestChunkedCollector.

### DIFF
--- a/collector_test.go
+++ b/collector_test.go
@@ -11,7 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"sort"
+
 	"sourcegraph.com/sourcegraph/appdash/internal/wire"
+	"sourcegraph.com/sourcegraph/appdash/testutil"
 )
 
 func TestCollectorServer(t *testing.T) {
@@ -211,6 +214,8 @@ func TestChunkedCollector(t *testing.T) {
 		newCollectPacket(SpanID{1, 2, 3}, Annotations{{"k1", []byte("v1")}, {"k2", []byte("v2")}, {"k4", []byte("v4")}}),
 		newCollectPacket(SpanID{2, 3, 4}, Annotations{{"k3", []byte("v3")}}),
 	}
+	sort.Sort(testutil.CollectPackets(packets))
+	sort.Sort(testutil.CollectPackets(want))
 	if !reflect.DeepEqual(packets, want) {
 		t.Errorf("after MinInterval: got packets == %v, want %v", packets, want)
 	}

--- a/collector_test.go
+++ b/collector_test.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 
 	"sourcegraph.com/sourcegraph/appdash/internal/wire"
-	"sourcegraph.com/sourcegraph/appdash/testutil"
 )
 
 func TestCollectorServer(t *testing.T) {
@@ -214,8 +213,8 @@ func TestChunkedCollector(t *testing.T) {
 		newCollectPacket(SpanID{1, 2, 3}, Annotations{{"k1", []byte("v1")}, {"k2", []byte("v2")}, {"k4", []byte("v4")}}),
 		newCollectPacket(SpanID{2, 3, 4}, Annotations{{"k3", []byte("v3")}}),
 	}
-	sort.Sort(testutil.CollectPackets(packets))
-	sort.Sort(testutil.CollectPackets(want))
+	sort.Sort(byTraceID(packets))
+	sort.Sort(byTraceID(want))
 	if !reflect.DeepEqual(packets, want) {
 		t.Errorf("after MinInterval: got packets == %v, want %v", packets, want)
 	}
@@ -320,3 +319,9 @@ func BenchmarkChunkedCollector500(b *testing.B) {
 		}
 	}
 }
+
+type byTraceID []*wire.CollectPacket
+
+func (bt byTraceID) Len() int           { return len(bt) }
+func (bt byTraceID) Swap(i, j int)      { bt[i], bt[j] = bt[j], bt[i] }
+func (bt byTraceID) Less(i, j int) bool { return *bt[i].Spanid.Trace < *bt[j].Spanid.Trace }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,0 +1,9 @@
+package testutil
+
+import "sourcegraph.com/sourcegraph/appdash/internal/wire"
+
+type CollectPackets []*wire.CollectPacket
+
+func (cp CollectPackets) Len() int           { return len(cp) }
+func (cp CollectPackets) Swap(i, j int)      { cp[i], cp[j] = cp[j], cp[i] }
+func (cp CollectPackets) Less(i, j int) bool { return *cp[i].Spanid.Trace < *cp[j].Spanid.Trace }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,9 +1,0 @@
-package testutil
-
-import "sourcegraph.com/sourcegraph/appdash/internal/wire"
-
-type CollectPackets []*wire.CollectPacket
-
-func (cp CollectPackets) Len() int           { return len(cp) }
-func (cp CollectPackets) Swap(i, j int)      { cp[i], cp[j] = cp[j], cp[i] }
-func (cp CollectPackets) Less(i, j int) bool { return *cp[i].Spanid.Trace < *cp[j].Spanid.Trace }


### PR DESCRIPTION
#### Details

Issue: #101 

- Improves `TestChunkedCollector` - it does intermittently fails becase `reflect.DeepEqual` cares about element position when comparing, so `expected` & `actual` variables being compare sometimes might have the same elements but in different order.
- [x] Adds `type byTraceID` which we do use to sort `[]*wire.CollectPacket` within `TestChunkedCollector`.