### PR TITLE
Adds support to hide timeline chart on `/traces/:trace_id`

### DIFF
--- a/traceapp/app.go
+++ b/traceapp/app.go
@@ -110,8 +110,16 @@ func (a *App) serveTrace(w http.ResponseWriter, r *http.Request) error {
 		return a.profile(trace, w)
 	}
 
+	// Do not show d3 timeline chart when timeline item fields are invalid.
+	// So we avoid JS code breaking due missing values.
+	var showTimelineChart bool = true
 	visData, err := a.d3timeline(trace)
-	if err != nil {
+	switch err {
+	case ErrTimelineItemValidation:
+		showTimelineChart = false
+	case nil:
+		break
+	default:
 		return err
 	}
 
@@ -128,13 +136,15 @@ func (a *App) serveTrace(w http.ResponseWriter, r *http.Request) error {
 
 	return a.renderTemplate(w, r, "trace.html", http.StatusOK, &struct {
 		TemplateCommon
-		Trace      *appdash.Trace
-		VisData    []timelineItem
-		ProfileURL string
+		Trace             *appdash.Trace
+		ShowTimelineChart bool
+		VisData           []timelineItem
+		ProfileURL        string
 	}{
-		Trace:      trace,
-		VisData:    visData,
-		ProfileURL: profile.String(),
+		Trace:             trace,
+		ShowTimelineChart: showTimelineChart,
+		VisData:           visData,
+		ProfileURL:        profile.String(),
 	})
 }
 

--- a/traceapp/tmpl/data/trace.html
+++ b/traceapp/tmpl/data/trace.html
@@ -144,6 +144,7 @@
 <script type="text/javascript">
   (function() {
     var data = {{.VisData}};
+    var showTimelineChart = {{.ShowTimelineChart}};
     var width = $(".container").width();
 
     // em converts the input (in em units) to pixels units and returns it.
@@ -438,7 +439,7 @@
       });
     }
 
-    if(data != null) {
+    if(data != null && showTimelineChart) {
       timelineHover();
     }
 


### PR DESCRIPTION
#### Details

When visiting `/traces/:trace_id` d3 timeline chart is drawn which depends on `timelineItem.Label` and `timelineItem.FullLabel`, so when missing those values, frontend hangs forever.

- [x] Adds support for new variable: `showTimelineChart ` used on `traceapp/tmpl/data/trace.html`
  - Which is set to false when `timelineItem.Label` or `timelineItem.FullLabel` are empty.
  - When `showTimelineChart` is false, timeline chart is not drawn and we prevent the issue mentioned above.

/cc: @slimsag 
