### PR TITLE
Improvements on `D3 Timeline` data.

### DIFF
--- a/traceapp/vis.go
+++ b/traceapp/vis.go
@@ -92,6 +92,11 @@ func (a *App) d3timelineInner(t *appdash.Trace, depth int) ([]timelineItem, erro
 	}
 	for _, e := range events {
 		if e, ok := e.(appdash.TimespanEvent); ok {
+			// Continue to next iteration
+			// if e.Start() or e.End() are empty time values.
+			if e.Start() == (time.Time{}) || e.End() == (time.Time{}) {
+				continue
+			}
 			start := e.Start().UnixNano() / int64(time.Millisecond)
 			end := e.End().UnixNano() / int64(time.Millisecond)
 			ts := timelineItemTimespan{


### PR DESCRIPTION
#### Details

- [x] Adds empty checking to `event.Start()` & `event.End()` values, so no empty `times` are added and later returned to the frontend where it's being use to draw d3 timeline chart, which would crash when trying to use an empty value from `times`.

Notes: 
- I've discovered this while working on #99:

- Based on `examples/cmd/webapp/main.go`:
  - `MemoryStore` - won't save `_schema:HTTPClient` `Event` for root spans.
  - When building d3 timeline data for a given root span - everything is fine, all other events different than (`_schema:HTTPClient`) are present & contains values.

- Based on `examples/cmd/webapp-influxdb/main.go`:
  - `InfluxDBStore` - won't save `_schema:HTTPClient` `Event` for root spans.
  - When building d3 timeline data for a given root span, event: `_schema:HTTPClient` & it's associated times are present & it's values are empty, not because we did saved but because `InfluxDB` will include in the query result all the `fields` from the `measurement` - and the field `_schema:HTTPClient` was created for other spans.
  - We can think about it as: First we write to DB a new root span which does not contain `_schema:HTTPClient` as field so obviously it is not created on spans `measurement` - later a child span is saved to DB which does have `_schema:HTTPClient` as field, so this new field is created and for the existing spans the value of this new field is set to empty - said that, when doing queries like `SELECT * FROM SPANS WHERE trace_id=ABC` - will include all fields for measurement `spans` all those used when inserting `trace_id=ABC` and the ones that weren't, those last one with empty values.