### PR TITLE
Adds the Appdash implementation of the OpenTracing API

### DIFF
--- a/event.go
+++ b/event.go
@@ -126,6 +126,7 @@ func init() {
 	RegisterEvent(logEvent{})
 	RegisterEvent(msgEvent{})
 	RegisterEvent(timespanEvent{})
+	RegisterEvent(Timespan{})
 }
 
 // UnmarshalEvents unmarshals all events found in anns into
@@ -151,6 +152,11 @@ func UnmarshalEvents(anns Annotations, events *[]Event) error {
 type spanName struct{ Name string }
 
 func (spanName) Schema() string { return "name" }
+
+// SpanName returns an Event containing a human readable Span name.
+func SpanName(name string) Event {
+	return spanName{Name: name}
+}
 
 // Msg returns an Event that contains only a human-readable message.
 func Msg(msg string) Event {
@@ -179,6 +185,17 @@ func (timespanEvent) Schema() string      { return "timespan" }
 func (ev timespanEvent) Start() time.Time { return ev.S }
 func (ev timespanEvent) End() time.Time   { return ev.E }
 
+// Timespan is an event that satisfies the appdash.TimespanEvent interface.
+// This is used to show its beginning and end times of a span.
+type Timespan struct {
+	S time.Time `trace:"Span.Start"`
+	E time.Time `trace:"Span.End"`
+}
+
+func (s Timespan) Schema() string   { return "Timespan" }
+func (s Timespan) Start() time.Time { return s.S }
+func (s Timespan) End() time.Time   { return s.E }
+
 // A TimestampedEvent is an Event with a timestamp.
 type TimestampedEvent interface {
 	Timestamp() time.Time
@@ -188,6 +205,12 @@ type TimestampedEvent interface {
 // contains only a human-readable message.
 func Log(msg string) Event {
 	return logEvent{Msg: msg, Time: time.Now()}
+}
+
+// LogWithTimestamp returns an Event with an explicit timestamp that contains
+// only a human readable message.
+func LogWithTimestamp(msg string, timestamp time.Time) logEvent {
+	return logEvent{Msg: msg, Time: timestamp}
 }
 
 type logEvent struct {

--- a/examples/cmd/webapp-opentracing/main.go
+++ b/examples/cmd/webapp-opentracing/main.go
@@ -1,0 +1,156 @@
+// webapp: a standalone example Negroni / Gorilla based webapp.
+//
+// This example demonstrates basic usage of Appdash in a Negroni / Gorilla
+// based web application. The entire application is ran locally (i.e. on the
+// same server) -- even the Appdash web UI.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"sourcegraph.com/sourcegraph/appdash"
+	appdashtracer "sourcegraph.com/sourcegraph/appdash/opentracing"
+	"sourcegraph.com/sourcegraph/appdash/traceapp"
+
+	"github.com/codegangsta/negroni"
+	"github.com/gorilla/mux"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+func main() {
+	// Create a recent in-memory store, evicting data after 20s.
+	//
+	// The store defines where information about traces (i.e. spans and
+	// annotations) will be stored during the lifetime of the application. This
+	// application uses a MemoryStore store wrapped by a RecentStore with an
+	// eviction time of 20s (i.e. all data after 20s is deleted from memory).
+	memStore := appdash.NewMemoryStore()
+	store := &appdash.RecentStore{
+		MinEvictAge: 20 * time.Second,
+		DeleteStore: memStore,
+	}
+
+	// Start the Appdash web UI on port 8700.
+	//
+	// This is the actual Appdash web UI -- usable as a Go package itself, We
+	// embed it directly into our application such that visiting the web server
+	// on HTTP port 8700 will bring us to the web UI, displaying information
+	// about this specific web-server (another alternative would be to connect
+	// to a centralized Appdash collection server).
+	tapp := traceapp.New(nil)
+	tapp.Store = store
+	tapp.Queryer = memStore
+	log.Println("Appdash web UI running on HTTP :8700")
+	go func() {
+		log.Fatal(http.ListenAndServe(":8700", tapp))
+	}()
+
+	// We will use a local collector (as we are running the Appdash web UI
+	// embedded within our app).
+	//
+	// A collector is responsible for collecting the information about traces
+	// (i.e. spans and annotations) and placing them into a store. In this app
+	// we use a local collector (we could also use a remote collector, sending
+	// the information to a remote Appdash collection server).
+	collector := appdash.NewLocalCollector(store)
+
+	// Here we use the local collector to create a new opentracing.Tracer
+	tracer := appdashtracer.NewTracer(collector)
+	opentracing.InitGlobalTracer(tracer)
+
+	// Setup our router (for information, see the gorilla/mux docs):
+	router := mux.NewRouter()
+	router.HandleFunc("/", Home)
+	router.HandleFunc("/endpoint", Endpoint)
+
+	// Setup Negroni for our app (for information, see the negroni docs):
+	n := negroni.Classic()
+	n.UseHandler(router)
+	n.Run(":8699")
+}
+
+// Home is the homepage handler for our app.
+func Home(w http.ResponseWriter, r *http.Request) {
+	// Start a new root Span and therefore a new trace.
+	span := opentracing.StartSpan(r.URL.Path)
+	defer span.Finish()
+
+	// OpenTracing allows for arbritary tags to be added to a Span.
+	span.SetTag("Request.Host", r.Host)
+	span.SetTag("Request.Address", r.RemoteAddr)
+	addHeaderTags(span, r.Header)
+
+	// Baggage Items are similar to tags, however they are propagated to all
+	// children spans, so this will show up in the API calls.
+	span.SetBaggageItem("User", os.Getenv("USER"))
+
+	// We're going to make some API request, so we use the default HTTP client
+	// to send HTTP requests with trace information placed inside the headers.
+	httpClient := http.DefaultClient
+
+	// Make three API requests using our HTTP client.
+	for i := 0; i < 3; i++ {
+		req, err := http.NewRequest("GET", "http://localhost:8699/endpoint", nil)
+		if err != nil {
+			log.Println("/endpoint:", err)
+			continue
+		}
+
+		// We inject the span into the request headers before making the request.
+		carrier := opentracing.HTTPHeaderTextMapCarrier(req.Header)
+		span.Tracer().Inject(span, opentracing.TextMap, carrier)
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			log.Println("/endpoint:", err)
+
+			// Log the error to the span.
+			span.LogEvent(err.Error())
+			continue
+		}
+
+		span.SetTag("Response.Status", resp.Status)
+		resp.Body.Close()
+	}
+
+	// Render the page.
+	fmt.Fprintf(w, `<p>Three API requests have been made!</p>`)
+	fmt.Fprintf(w, `<p><a href="http://localhost:8700/traces" target="_">View the trace</a></p>`)
+}
+
+// Endpoint is an example API endpoint. In a real application, the backend of
+// your service would be contacting several external and internal API endpoints
+// which may be the bottleneck of your application.
+//
+// For example purposes we just sleep for 200ms before responding to simulate a
+// slow API endpoint as the bottleneck of your application.
+func Endpoint(w http.ResponseWriter, r *http.Request) {
+	// Extract the trace from the headers and join it with a new child span.
+	carrier := opentracing.HTTPHeaderTextMapCarrier(r.Header)
+	span, err := opentracing.GlobalTracer().Join(r.URL.Path, opentracing.TextMap, carrier)
+	if err != nil {
+		return
+	}
+	defer span.Finish()
+
+	span.SetTag("Request.Host", r.Host)
+	span.SetTag("Request.Method", r.Method)
+	addHeaderTags(span, r.Header)
+
+	time.Sleep(200 * time.Millisecond)
+	fmt.Fprintf(w, "Slept for 200ms!")
+}
+
+const headerTagPrefix = "Request.Header."
+
+// addHeaderTags adds header key:value pairs to a span as a tag with the prefix
+// "Request.Header.*"
+func addHeaderTags(span opentracing.Span, h http.Header) {
+	for k, v := range h {
+		span.SetTag(headerTagPrefix+k, strings.Join(v, ", "))
+	}
+}

--- a/opentracing/recorder.go
+++ b/opentracing/recorder.go
@@ -1,0 +1,102 @@
+// Package opentracing provides an Appdash implementation of the OpenTracing
+// API.
+//
+// The OpenTracing specification allows for Span Tags to have an arbitrary
+// value. The way the Appdash.Recorder handles this is by converting the
+// tag value into a string using the default format for its type. Arbitrary
+// structs have their field name included.
+//
+// The Appdash implementation also does not record Log payloads.
+package opentracing
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	basictracer "github.com/opentracing/basictracer-go"
+	"sourcegraph.com/sourcegraph/appdash"
+)
+
+// Recorder implements the basictracer.Recorder interface.
+type Recorder struct {
+	collector appdash.Collector
+	logOnce   sync.Once
+	verbose   bool
+	Log       *log.Logger
+}
+
+// NewRecorder forwards basictracer.RawSpans to an appdash.Collector.
+func NewRecorder(collector appdash.Collector, opts Options) *Recorder {
+	if opts.Logger == nil {
+		opts.Logger = newLogger()
+	}
+	return &Recorder{
+		collector: collector,
+		verbose:   opts.Verbose,
+		Log:       opts.Logger,
+	}
+}
+
+// RecordSpan converts a RawSpan into the Appdash representation of a span
+// and records it to the underlying collector.
+func (r *Recorder) RecordSpan(sp basictracer.RawSpan) {
+	spanID := appdash.SpanID{
+		Span:   appdash.ID(uint64(sp.SpanID)),
+		Trace:  appdash.ID(uint64(sp.TraceID)),
+		Parent: appdash.ID(uint64(sp.ParentSpanID)),
+	}
+
+	r.collectEvent(spanID, appdash.SpanName(sp.Operation))
+
+	// Record all of the logs. Payloads are thrown out.
+	for _, log := range sp.Logs {
+		r.collectEvent(spanID, appdash.LogWithTimestamp(log.Event, log.Timestamp))
+	}
+
+	for key, value := range sp.Tags {
+		val := []byte(fmt.Sprintf("%+v", value))
+		r.collectAnnotation(spanID, appdash.Annotation{Key: key, Value: val})
+	}
+
+	for key, val := range sp.Baggage {
+		r.collectAnnotation(spanID, appdash.Annotation{Key: key, Value: []byte(val)})
+	}
+
+	// Add the duration to the start time to get an approximate end time.
+	approxEndTime := sp.Start.Add(sp.Duration)
+	r.collectEvent(spanID, appdash.Timespan{S: sp.Start, E: approxEndTime})
+}
+
+// collectEvent marshals and collects the Event.
+func (r *Recorder) collectEvent(spanID appdash.SpanID, e appdash.Event) {
+	ans, err := appdash.MarshalEvent(e)
+	if err != nil {
+		r.logError(spanID, err)
+		return
+	}
+	r.collectAnnotation(spanID, ans...)
+}
+
+func (r *Recorder) collectAnnotation(spanID appdash.SpanID, ans ...appdash.Annotation) {
+	err := r.collector.Collect(spanID, ans...)
+	if err != nil {
+		r.logError(spanID, err)
+	}
+}
+
+// logError converts an error into a log event and collects it.
+// If for whatever reason the error can't be collected, it is logged to the
+// Recorder's logger if it is non-nil.
+func (r *Recorder) logError(spanID appdash.SpanID, err error) {
+	ans, _ := appdash.MarshalEvent(appdash.Log(err.Error()))
+
+	// At this point, something is definitely wrong.
+	if err := r.collector.Collect(spanID, ans...); err != nil {
+		if r.verbose {
+			r.Log.Printf("Appdash Recorder collect error: %v\n", err)
+		} else {
+			r.logOnce.Do(func() { r.Log.Printf("Appdash Recorder collect error: %v\n", err) })
+		}
+	}
+}

--- a/opentracing/recorder_test.go
+++ b/opentracing/recorder_test.go
@@ -1,0 +1,121 @@
+package opentracing
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	basictracer "github.com/opentracing/basictracer-go"
+
+	"sourcegraph.com/sourcegraph/appdash"
+	"sourcegraph.com/sourcegraph/appdash/internal/wire"
+)
+
+func TestOpentracingRecorder(t *testing.T) {
+	var packets []*wire.CollectPacket
+	mc := collectorFunc(func(span appdash.SpanID, anns ...appdash.Annotation) error {
+		packets = append(packets, newCollectPacket(span, anns))
+		return nil
+	})
+
+	baggageKey := "somelongval"
+	baggageVal := "val"
+	opName := "testOperation"
+
+	r := NewRecorder(mc, Options{})
+	raw := basictracer.RawSpan{
+		Context: basictracer.Context{
+			TraceID:      1,
+			SpanID:       2,
+			ParentSpanID: 3,
+		},
+		Tags: map[string]interface{}{
+			"tag": 1,
+		},
+		Baggage: map[string]string{
+			baggageKey: baggageVal,
+		},
+		Operation: opName,
+		Duration:  time.Duration(1),
+	}
+
+	r.RecordSpan(raw)
+
+	tsAnnotations := marshalEvent(appdash.Timespan{raw.Start, raw.Start.Add(raw.Duration)})
+	want := []*wire.CollectPacket{
+		newCollectPacket(appdash.SpanID{1, 2, 3}, appdash.Annotations{{"tag", []byte("1")}}),
+		newCollectPacket(appdash.SpanID{1, 2, 3}, appdash.Annotations{{baggageKey, []byte(baggageVal)}}),
+		newCollectPacket(appdash.SpanID{1, 2, 3}, marshalEvent(appdash.SpanName(opName))),
+		newCollectPacket(appdash.SpanID{1, 2, 3}, tsAnnotations),
+	}
+
+	sort.Sort(byTraceID(packets))
+	sort.Sort(byTraceID(want))
+	if !reflect.DeepEqual(packets, want) {
+		t.Errorf("Got packets %v, want %v", packets, want)
+	}
+}
+
+// newCollectPacket returns an initialized *wire.CollectPacket given a span and
+// set of annotations.
+func newCollectPacket(s appdash.SpanID, as appdash.Annotations) *wire.CollectPacket {
+	swire := &wire.CollectPacket_SpanID{
+		Trace:  (*uint64)(&s.Trace),
+		Span:   (*uint64)(&s.Span),
+		Parent: (*uint64)(&s.Parent),
+	}
+	w := []*wire.CollectPacket_Annotation{}
+
+	for _, a := range as {
+		// Important: Make a copy of a that we can retain a pointer to that
+		// doesn't change after each iteration. Otherwise all wire annotations
+		// would have the same key.
+		cpy := a
+		w = append(w, &wire.CollectPacket_Annotation{
+			Key:   &cpy.Key,
+			Value: cpy.Value,
+		})
+	}
+	return &wire.CollectPacket{
+		Spanid:     swire,
+		Annotation: w,
+	}
+}
+
+type collectorFunc func(appdash.SpanID, ...appdash.Annotation) error
+
+// Collect implements the Collector interface by calling the function itself.
+func (c collectorFunc) Collect(id appdash.SpanID, as ...appdash.Annotation) error {
+	return c(id, as...)
+}
+
+func marshalEvent(e appdash.Event) appdash.Annotations {
+	ans, _ := appdash.MarshalEvent(e)
+	return ans
+}
+
+type byTraceID []*wire.CollectPacket
+
+func (bt byTraceID) Len() int      { return len(bt) }
+func (bt byTraceID) Swap(i, j int) { bt[i], bt[j] = bt[j], bt[i] }
+func (bt byTraceID) Less(i, j int) bool {
+	if *bt[i].Spanid.Trace < *bt[j].Spanid.Trace {
+		return true
+	}
+
+	// If the packet has more than one annotation, sort those annotation by name.
+	if len(bt[i].Annotation) > 1 {
+		sort.Sort(byAnnotation(bt[i].Annotation))
+	}
+	if len(bt[j].Annotation) > 1 {
+		sort.Sort(byAnnotation(bt[i].Annotation))
+	}
+	return *bt[i].Annotation[0].Key < *bt[j].Annotation[0].Key
+}
+
+type byAnnotation []*wire.CollectPacket_Annotation
+
+func (bt byAnnotation) Len() int           { return len(bt) }
+func (bt byAnnotation) Swap(i, j int)      { bt[i], bt[j] = bt[j], bt[i] }
+func (bt byAnnotation) Less(i, j int) bool { return *bt[i].Key < *bt[j].Key }

--- a/opentracing/tracer.go
+++ b/opentracing/tracer.go
@@ -1,0 +1,81 @@
+package opentracing
+
+import (
+	"log"
+	"os"
+
+	basictracer "github.com/opentracing/basictracer-go"
+	opentracing "github.com/opentracing/opentracing-go"
+	"sourcegraph.com/sourcegraph/appdash"
+)
+
+var _ opentracing.Tracer = NewTracer(nil) // Compile time check.
+
+// Options defines options for a Tracer.
+type Options struct {
+	// ShouldSample is a function that allows deterministic sampling of a trace
+	// using the randomly generated Trace ID. The decision is made when a new Trace
+	// is created and is propagated to all of the trace's spans. For example,
+	//
+	//   func(traceID int64) { return traceID % 128 == 0 }
+	//
+	// samples 1 in every 128 traces, approximately.
+	ShouldSample func(traceID int64) bool
+
+	// Verbose determines whether errors are logged to stdout only once or all
+	// the time. By default, Verbose is false so only the first error is logged
+	// and the rest are silenced.
+	Verbose bool
+
+	// Logger is used to log critical errors that can't be collected by the
+	// Appdash Collector.
+	Logger *log.Logger
+}
+
+func newLogger() *log.Logger {
+	return log.New(os.Stderr, "opentracing: ", log.LstdFlags)
+}
+
+// DefaultOptions creates an Option with a sampling function that always return
+// true and a logger that logs errors to stderr.
+func DefaultOptions() Options {
+	return Options{
+		ShouldSample: func(_ int64) bool { return true },
+		Logger:       newLogger(),
+	}
+}
+
+// NewTracer creates a new opentracing.Tracer implementation that reports
+// spans to an Appdash collector.
+//
+// The Tracer created by NewTracer reports all spans by default. If you want to
+// sample 1 in every N spans, see NewTracerWithOptions. Spans are written to
+// the underlying collector when Finish() is called on the span. It is
+// possible to buffer and write span on a time interval using appdash.ChunkedCollector.
+//
+// For example:
+//
+//   collector := appdash.NewLocalCollector(myAppdashStore)
+//   chunkedCollector := appdash.NewChunkedCollector(collector)
+//
+//   tracer := NewTracer(chunkedCollector)
+//
+// If writing traces to a remote Appdash collector, an appdash.RemoteCollector would
+// be needed, for example:
+//
+//   collector := appdash.NewRemoteCollector("localhost:8700")
+//   tracer := NewTracer(collector)
+//
+// will record all spans to a collector server on localhost:8700.
+func NewTracer(c appdash.Collector) opentracing.Tracer {
+	return NewTracerWithOptions(c, DefaultOptions())
+}
+
+// NewTracerWithOptions creates a new opentracing.Tracer that records spans to
+// the given appdash.Collector.
+func NewTracerWithOptions(c appdash.Collector, options Options) opentracing.Tracer {
+	opts := basictracer.DefaultOptions()
+	opts.ShouldSample = options.ShouldSample
+	opts.Recorder = NewRecorder(c, options)
+	return basictracer.NewWithOptions(opts)
+}

--- a/recorder.go
+++ b/recorder.go
@@ -3,6 +3,7 @@ package appdash
 import (
 	"fmt"
 	"sync"
+	"time"
 )
 
 // A Recorder is associated with a span and records annotations on the
@@ -49,6 +50,11 @@ func (r *Recorder) Msg(msg string) {
 // human-readable message) on the span.
 func (r *Recorder) Log(msg string) {
 	r.Event(Log(msg))
+}
+
+// LogWithTimestamp records a Log event with an explicit timestamp
+func (r *Recorder) LogWithTimestamp(msg string, timestamp time.Time) {
+	r.Event(LogWithTimestamp(msg, timestamp))
 }
 
 // Event records any event that implements the Event, TimespanEvent, or


### PR DESCRIPTION
This is the Appdash implementation of the OpenTracing api for Go. This is a really big diff, so I'd recommend ignoring the tests and the example app that's included for the time being. cc @slimsag 