### PR TITLE
traceapp: Always use 500 HTTP status code for errors.

### DIFF
--- a/traceapp/handler.go
+++ b/traceapp/handler.go
@@ -13,25 +13,25 @@ type handlerFunc func(http.ResponseWriter, *http.Request) error
 func (h handlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var rb responseBuffer
 
-	handleError := func(err error) {
-		log.Printf("%s %s: HTTP %d: %s", r.Method, r.URL.RequestURI(), rb.Status, err.Error())
-
-		// Never cache error responses.
-		w.Header().Set("cache-control", "no-cache, max-age=0")
-
-		http.Error(w, err.Error(), rb.Status)
-	}
-
 	defer func() {
 		if rv := recover(); rv != nil {
-			handleError(fmt.Errorf("handler panic\n\n%s\n\n%s", rv, debug.Stack()))
+			handleError(w, r, fmt.Errorf("handler panic\n\n%s\n\n%s", rv, debug.Stack()))
 		}
 	}()
 
 	err := h(&rb, r)
 	if err != nil {
-		handleError(err)
+		handleError(w, r, err)
 		return
 	}
 	rb.WriteTo(w)
+}
+
+func handleError(w http.ResponseWriter, r *http.Request, err error) {
+	log.Printf("%s %s: error: %s", r.Method, r.URL.RequestURI(), err.Error())
+
+	// Never cache error responses.
+	w.Header().Set("cache-control", "no-cache, max-age=0")
+
+	http.Error(w, err.Error(), http.StatusInternalServerError)
 }


### PR DESCRIPTION
Currently, the value of `rb.Status` is often `0` when an error happens. This is because in many error conditions, its value is never changed from its initial zero value when the error happens. This is an invalid HTTP status code that may be causing issues when serving via HTTP/2.

Always use 500 HTTP status code, which is is simpler and guaranteed to work in all situations. If desired to have more descriptive error messages, that can be an optional followup.

This may fix issues with responding to requests over HTTP/2.

Refactor `handleError` so it's no longer a closure.