### PR TITLE
add queueSize parameter to ChunkedCollector.OnFlush

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -57,7 +57,7 @@ type ChunkedCollector struct {
 	// operation that is performed by this collector.
 	//
 	// It is primarily used for debugging purposes.
-	OnFlush func()
+	OnFlush func(queueSize int)
 
 	// The last error from the underlying Collector's Collect method,
 	// if any. It will be returned to the next caller of Collect and
@@ -109,14 +109,14 @@ func (cc *ChunkedCollector) Collect(span SpanID, anns ...Annotation) error {
 // Flush immediately sends all pending spans to the underlying
 // collector.
 func (cc *ChunkedCollector) Flush() error {
-	if cc.OnFlush != nil {
-		cc.OnFlush()
-	}
-
 	cc.mu.Lock()
 	pendingBySpanID := cc.pendingBySpanID
 	cc.pendingBySpanID = nil
 	cc.mu.Unlock()
+
+	if cc.OnFlush != nil {
+		cc.OnFlush(len(pendingBySpanID))
+	}
 
 	var errs []error
 	for spanID, p := range pendingBySpanID {


### PR DESCRIPTION
This enables us to debug what appears to be a queue buildup causing
Flush operations to take much longer and eventually leak memory.