### PR TITLE
add a FlushTimeout field to ChunkedCollector to prevent memory consumption

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -94,9 +94,10 @@ type ChunkedCollector struct {
 	// Default FlushTimeout = 50 * time.Millisecond (50ms).
 	FlushTimeout time.Duration
 
-	// MaxQueueSize is the maximum size in bytes that the pending queue of
-	// collections may grow to before being entirely dropped (trace data lost).
-	// In the event that the queue is dropped, Collect will return ErrQueueDropped.
+	// MaxQueueSize, if non-zero, is the maximum size in bytes that the pending
+	// queue of collections may grow to before being entirely dropped (trace data
+	// lost). In the event that the queue is dropped, Collect will return
+	// ErrQueueDropped.
 	//
 	// Default MaxQueueSize = 32 * 1024 * 1024 (32MB).
 	MaxQueueSize uint64
@@ -170,7 +171,7 @@ func (cc *ChunkedCollector) Collect(span SpanID, anns ...Annotation) error {
 		collectionSize += uint64(len(ann.Key))
 		collectionSize += uint64(len(ann.Value))
 	}
-	if cc.queueSizeBytes+collectionSize > cc.MaxQueueSize {
+	if cc.MaxQueueSize != 0 && cc.queueSizeBytes+collectionSize > cc.MaxQueueSize {
 		// Queue is too large, drop it.
 		cc.pendingBySpanID = nil
 		cc.queueSizeBytes = 0

--- a/collector.go
+++ b/collector.go
@@ -129,7 +129,7 @@ type ChunkedCollector struct {
 	mu sync.Mutex
 }
 
-// NewChunkedCollector is short-handed for:
+// NewChunkedCollector is shorthand for:
 //
 // 	c := &ChunkedCollector{
 // 		Collector:    c,

--- a/collector.go
+++ b/collector.go
@@ -136,7 +136,7 @@ type ChunkedCollector struct {
 // 		MinInterval:  500 * time.Millisecond,
 // 		FlushTimeout: 50 * time.Millisecond,
 // 		MaxQueueSize: 32 * 1024 * 1024, // 32MB
-// 		Log:          log.New(os.Stderr, "appdash", log.LstdFlags),
+// 		Log:          log.New(os.Stderr, "appdash: ", log.LstdFlags),
 // 	}
 //
 func NewChunkedCollector(c Collector) *ChunkedCollector {
@@ -145,7 +145,7 @@ func NewChunkedCollector(c Collector) *ChunkedCollector {
 		MinInterval:  500 * time.Millisecond,
 		FlushTimeout: 50 * time.Millisecond,
 		MaxQueueSize: 32 * 1024 * 1024, // 32MB
-		Log:          log.New(os.Stderr, "appdash", log.LstdFlags),
+		Log:          log.New(os.Stderr, "appdash: ", log.LstdFlags),
 	}
 }
 

--- a/collector.go
+++ b/collector.go
@@ -19,7 +19,7 @@ import (
 // Effectively, the client may request the server to allocate a buffer of up to
 // maxMessageSize -- so choose carefully.
 //
-// We use 1MB here.
+// We use 1 MB here.
 const maxMessageSize = 1 * 1024 * 1024
 
 // A Collector collects events that occur in spans.
@@ -99,7 +99,7 @@ type ChunkedCollector struct {
 	// lost). In the event that the queue is dropped, Collect will return
 	// ErrQueueDropped.
 	//
-	// Default MaxQueueSize = 32 * 1024 * 1024 (32MB).
+	// Default MaxQueueSize = 32 * 1024 * 1024 (32 MB).
 	MaxQueueSize uint64
 
 	// Log, if non-nil, is used to log warnings like when the queue is entirely
@@ -135,7 +135,7 @@ type ChunkedCollector struct {
 // 		Collector:    c,
 // 		MinInterval:  500 * time.Millisecond,
 // 		FlushTimeout: 50 * time.Millisecond,
-// 		MaxQueueSize: 32 * 1024 * 1024, // 32MB
+// 		MaxQueueSize: 32 * 1024 * 1024, // 32 MB
 // 		Log:          log.New(os.Stderr, "appdash: ", log.LstdFlags),
 // 	}
 //
@@ -144,7 +144,7 @@ func NewChunkedCollector(c Collector) *ChunkedCollector {
 		Collector:    c,
 		MinInterval:  500 * time.Millisecond,
 		FlushTimeout: 50 * time.Millisecond,
-		MaxQueueSize: 32 * 1024 * 1024, // 32MB
+		MaxQueueSize: 32 * 1024 * 1024, // 32 MB
 		Log:          log.New(os.Stderr, "appdash: ", log.LstdFlags),
 	}
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -246,8 +246,8 @@ func TestChunkedCollectorFlushTimeout(t *testing.T) {
 	}
 
 	err := cc.Flush()
-	if err != ErrFlushTimeout {
-		t.Fatal("got", err, "expected", ErrFlushTimeout)
+	if err != ErrQueueDropped {
+		t.Fatal("got", err, "expected", ErrQueueDropped)
 	}
 	if len(cc.pendingBySpanID) != 0 {
 		t.Fatal("got", len(cc.pendingBySpanID), "queued but expected 0")


### PR DESCRIPTION
This change adds a FlushTimeout field to ChunkedCollector which can be used to prevent a large queue from building up within the ChunkedCollector, effectively leaking/consuming large amounts of memory, due to an misbehaving underlying collector (like RemoteCollector, which would attempt to reconnect to a flaky remote server upon each collection).

/cc @neelance @keegancsmith 