### PR TITLE
Adds InfluxDBStore benchmarks.

### DIFF
--- a/influxdb_store_test.go
+++ b/influxdb_store_test.go
@@ -115,7 +115,10 @@ func TestFindTraceParent(t *testing.T) {
 }
 
 func TestInfluxDBStore(t *testing.T) {
-	store := newStore(t)
+	store, err := newTestInfluxDBStore()
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		if err := store.Close(); err != nil {
 			t.Fatal(err)
@@ -254,12 +257,234 @@ func TestInfluxDBStore(t *testing.T) {
 	}
 }
 
-func newStore(t *testing.T) *InfluxDBStore {
+func benchmarkInfluxDBStoreCollect(b *testing.B, n int) {
+	b.StopTimer()
+	store, err := newTestInfluxDBStore()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}()
+	b.StartTimer()
+	var x ID
+	for n := 0; n < b.N; n++ {
+		for c := 0; c < n; c++ {
+			x++
+			spanID := SpanID{x, x + 1, 0}
+			anns := []Annotations{
+				Annotations{
+					Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
+					Annotation{Key: "Server.Request.Headers.User-Agent", Value: []byte("Go-http-client/1.1")},
+					Annotation{Key: serverEventKey, Value: []byte("")},
+				},
+				Annotations{
+					Annotation{Key: "Name", Value: []byte("/")},
+				},
+				Annotations{
+					Annotation{Key: "Client.Response.Headers.Content-Type", Value: []byte("text/plain; charset=utf-8")},
+					Annotation{Key: "Client.Response.Headers.Content-Length", Value: []byte("16")},
+					Annotation{Key: clientEventKey, Value: []byte("")},
+				},
+			}
+			for ann := 0; ann < len(anns); ann++ {
+				if err := store.Collect(spanID, anns[ann]...); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkInfluxDBStoreCollect100(b *testing.B) {
+	benchmarkInfluxDBStoreCollect(b, 100)
+}
+
+func BenchmarkInfluxDBStoreCollect250(b *testing.B) {
+	benchmarkInfluxDBStoreCollect(b, 250)
+}
+
+func BenchmarkInfluxDBStoreCollect1000(b *testing.B) {
+	benchmarkInfluxDBStoreCollect(b, 1000)
+}
+
+func benchmarkInfluxDBStoreTrace(b *testing.B, n int) {
+	b.StopTimer()
+	store, err := newTestInfluxDBStore()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}()
+	traces, err := benchmarkInfluxDBStoreCreateTraces(store, n)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		for _, trace := range traces {
+			if _, err := store.Trace(trace.ID.Trace); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkInfluxDBStoreTrace100(b *testing.B) {
+	benchmarkInfluxDBStoreTrace(b, 100)
+}
+
+func BenchmarkInfluxDBStoreTrace250(b *testing.B) {
+	benchmarkInfluxDBStoreTrace(b, 250)
+}
+
+func BenchmarkInfluxDBStoreTrace1000(b *testing.B) {
+	benchmarkInfluxDBStoreTrace(b, 1000)
+}
+
+func benchmarkInfluxDBStoreTraces(b *testing.B, n int) {
+	b.StopTimer()
+	store, err := newTestInfluxDBStore()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}()
+	if _, err := benchmarkInfluxDBStoreCreateTraces(store, n); err != nil {
+		b.Fatal(err)
+	}
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := store.Traces(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkInfluxDBStoreTracesDefaultPerPage(b *testing.B) {
+	benchmarkInfluxDBStoreTraces(b, defaultTracesPerPage)
+}
+
+func benchmarkInfluxDBStoreCreateTraces(store *InfluxDBStore, n int) ([]*Trace, error) {
+	var (
+		mustCollect    func(trace *Trace) error
+		mustCollectAll func(trace *Trace) error
+	)
+	mustCollect = func(trace *Trace) error {
+		if err := store.Collect(trace.Span.ID, trace.Span.Annotations...); err != nil {
+			return err
+		}
+		return nil
+	}
+	mustCollectAll = func(trace *Trace) error {
+		if err := mustCollect(trace); err != nil {
+			return err
+		}
+		for _, sub := range trace.Sub {
+			if err := mustCollect(sub); err != nil {
+				return err
+			}
+			if err := mustCollectAll(sub); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	var (
+		// Initial ID's for traces & sub-traces.
+		x      ID    = ID(0)     // Root.
+		s0     ID    = ID(n)     // Sub 0.
+		s1     ID    = ID(n * 2) // Sub 1.
+		s2     ID    = ID(n * 3) // Sub 2.
+		s3     ID    = ID(n * 4) // Sub 3.
+		ids    []*ID = []*ID{&x, &s0, &s1, &s2, &s3}
+		traces []*Trace
+	)
+	for c := 0; c < n; c++ {
+		for _, id := range ids {
+			*id++
+		}
+		trace := Trace{
+			Span: Span{
+				ID: SpanID{x, s0, 0},
+				Annotations: []Annotation{
+					Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
+					Annotation{Key: "Server.Request.Headers.User-Agent", Value: []byte("Go-http-client/1.1")},
+					Annotation{Key: serverEventKey, Value: []byte("")},
+					Annotation{Key: "Name", Value: []byte("/")},
+					Annotation{Key: "Client.Response.Headers.Content-Type", Value: []byte("text/plain; charset=utf-8")},
+					Annotation{Key: "Client.Response.Headers.Content-Length", Value: []byte("16")},
+					Annotation{Key: clientEventKey, Value: []byte("")},
+				},
+			},
+			Sub: []*Trace{
+				&Trace{
+					Span: Span{
+						ID: SpanID{Trace: x, Span: s1, Parent: s0},
+						Annotations: Annotations{
+							Annotation{Key: "Name", Value: []byte("localhost:8699/endpoint")},
+							Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
+							Annotation{Key: clientEventKey, Value: []byte("")},
+							Annotation{Key: serverEventKey, Value: []byte("")},
+						},
+					},
+					Sub: []*Trace{
+						&Trace{
+							Span: Span{
+								ID: SpanID{Trace: x, Span: s2, Parent: s1},
+								Annotations: Annotations{
+									Annotation{Key: "Name", Value: []byte("localhost:8699/sub1")},
+									Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
+									Annotation{Key: clientEventKey, Value: []byte("")},
+									Annotation{Key: serverEventKey, Value: []byte("")},
+								},
+							},
+							Sub: []*Trace{
+								&Trace{
+									Span: Span{
+										ID: SpanID{Trace: x, Span: s3, Parent: s2},
+										Annotations: Annotations{
+											Annotation{Key: "Name", Value: []byte("localhost:8699/sub2")},
+											Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
+											Annotation{Key: clientEventKey, Value: []byte("")},
+											Annotation{Key: serverEventKey, Value: []byte("")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		if err := mustCollectAll(&trace); err != nil {
+			return nil, err
+		}
+		traces = append(traces, &trace)
+	}
+	return traces, nil
+}
+
+func newTestInfluxDBStore() (*InfluxDBStore, error) {
 	conf, err := influxDBServer.NewDemoConfig()
 	if err != nil {
-		t.Fatalf("failed to create influxdb config, error: %v", err)
+		return nil, err
 	}
+	conf.Data.QueryLogEnabled = false
 	conf.HTTPD.AuthEnabled = true
+	conf.HTTPD.LogEnabled = false
+	conf.ReportingDisabled = true
 	user := InfluxDBAdminUser{Username: "demo", Password: "demo"}
 	defaultRP := InfluxDBRetentionPolicy{Name: "one_hour_only", Duration: "1h"}
 	store, err := NewInfluxDBStore(InfluxDBStoreConfig{
@@ -270,9 +495,9 @@ func newStore(t *testing.T) *InfluxDBStore {
 		Server:    conf,
 	})
 	if err != nil {
-		t.Fatalf("failed to create influxdb store, error: %v", err)
+		return nil, err
 	}
-	return store
+	return store, nil
 }
 
 // removeInfluxDBAnnotations removes annotations from `root` and it's subtraces; only those annotations that have as key present on `keys` will be removed.


### PR DESCRIPTION
#### Details

- Adds benchmarks for:
  - [x] `InfluxDBStore.Collect(...)`
  - [x] `InfluxDBStore.Trace(...)`
  - [x] `InfluxDBStore.Traces(...)`

- Adds parallel benchmark for:
  - [x] `InfluxDBStore.Collect(...)`

###### Benchmark results [1.4 GHz Intel Core i5 - 4 GB 1600 MHz DDR3 - 4 cores]: 

- `InfluxDBStore.Collect(...)`
```
$ go test -run=XYZ -bench BenchmarkInfluxDBStoreCollect. > collect
$ more collect

PASS
BenchmarkInfluxDBStoreCollect100-4           100        1103805936 ns/op
BenchmarkInfluxDBStoreCollect250-4           100        1364806193 ns/op
BenchmarkInfluxDBStoreCollect1000-4          100        1172157445 ns/op
ok      sourcegraph.com/sourcegraph/appdash     387.393s
```

- `InfluxDBStore.Trace(...)`
```
$ go test -run=XYZ -bench BenchmarkInfluxDBStoreTrace. -benchtime=40s > trace
$ more trace

PASS
BenchmarkInfluxDBStoreTrace100-4             200         411849069 ns/op
BenchmarkInfluxDBStoreTrace250-4              50        1051788921 ns/op
BenchmarkInfluxDBStoreTrace1000-4             10        4227713513 ns/op
ok      sourcegraph.com/sourcegraph/appdash     380.156s
```

- `InfluxDBStore.Traces(...)`
```
$ go test -run=XYZ -bench BenchmarkInfluxDBStoreTracesDefaultPerPage > traces
more traces

PASS
BenchmarkInfluxDBStoreTracesDefaultPerPage-4         100          13433622 ns/op
ok      sourcegraph.com/sourcegraph/appdash     10.595s
```

- Parallel - `InfluxDBStore.Collect(...)`
```
$ go test -run=XYZ -bench BenchmarkInfluxDBStoreCollectParallel. > collect-parallel
$ more collect-parallel

PASS
BenchmarkInfluxDBStoreCollectParallel-4      100          14740471 ns/op
ok      sourcegraph.com/sourcegraph/appdash     17.546s
```

***

Also went ahead and did stress testing against `TestInfluxDBStore` using the following bash script:

```bash
#!/usr/bin/env bash -e

go test -c
# comment above and uncomment below to enable the race builder
# go test -c -race
PKG=$(basename $(pwd))

while true ; do 
        export GOMAXPROCS=$[ 1 + $[ RANDOM % 128 ]]
        ./$PKG.test $@ 2>&1
done
```
> *Source: [Stress test your Go packages](http://dave.cheney.net/2013/06/19/stress-test-your-go-packages).*

```
$ stress.bash -test.v -test.run=TestInfluxDBStore
```
> Results of running `stress.bash` as showed above: Ran for ~2 hours and got 1717 & 877(race detector enabled) test passes.


