### PR TITLE
updates to keep influxdb metrics reporting enabled

### DIFF
--- a/examples/cmd/webapp-influxdb/main.go
+++ b/examples/cmd/webapp-influxdb/main.go
@@ -35,9 +35,8 @@ func main() {
 	conf.Retention.Enabled = true
 	conf.Retention.CheckInterval = toml.Duration(30 * time.Minute)
 
-	// Disables sending anonymous data to m.influxdb.com
-	// See: https://docs.influxdata.com/influxdb/v0.10/administration/config/#reporting-disabled-false
-	conf.ReportingDisabled = true
+	// If you do not want metrics to be reported (see: https://docs.influxdata.com/influxdb/v0.10/administration/config/#reporting-disabled-false) uncomment the following line:
+	//conf.ReportingDisabled = true
 
 	// InfluxDB server auth credentials. If user does not exist yet it will
 	// be created as admin user.


### PR DESCRIPTION
#### Details

- [x] Keeps InfluxDB reporting enabled(default behavior) & adds a comment to let know appdash users how to disable it.

- Based on previous [conversation](https://github.com/chris-ramon/appdash/commit/ef7a19ab740b35d385c3ef2f42675b55572cded1#commitcomment-16596523) on PR #99.
