### PR TITLE
Improvements on reassembling back annotations from InfluxDB.

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -87,10 +87,8 @@ func TestUnmarshalEvents(t *testing.T) {
 	defer func() {
 		registeredEvents = origRegisteredEvents
 	}()
+	registeredEvents = make(map[string]Event)
 
-	for k := range registeredEvents {
-		delete(registeredEvents, k)
-	}
 	RegisterEvent(dummyEvent{})
 	RegisterEvent(dummyEvent2{})
 

--- a/influxdb_store_test.go
+++ b/influxdb_store_test.go
@@ -10,11 +10,7 @@ import (
 )
 
 const (
-	clientEventKey    string = schemaPrefix + clientEventSchema
-	clientEventSchema string = "HTTPClient"
-	serverEventKey    string = schemaPrefix + serverEventSchema
-	serverEventSchema string = "HTTPServer"
-	spanNameSchema    string = "name"
+	eventSpanNameAnnotationKey string = schemaPrefix + "name"
 )
 
 func TestMergeSchemasField(t *testing.T) {
@@ -127,9 +123,7 @@ func TestInfluxDBStore(t *testing.T) {
 				ID: SpanID{1, 100, 0},
 				Annotations: Annotations{
 					Annotation{Key: "Name", Value: []byte("/")},
-					Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
-					Annotation{Key: clientEventKey, Value: []byte("")},
-					Annotation{Key: serverEventKey, Value: []byte("")},
+					Annotation{Key: eventSpanNameAnnotationKey},
 				},
 			},
 			Sub: []*Trace{
@@ -138,9 +132,7 @@ func TestInfluxDBStore(t *testing.T) {
 						ID: SpanID{Trace: 1, Span: 11, Parent: 100},
 						Annotations: Annotations{
 							Annotation{Key: "Name", Value: []byte("localhost:8699/endpoint")},
-							Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
-							Annotation{Key: clientEventKey, Value: []byte("")},
-							Annotation{Key: serverEventKey, Value: []byte("")},
+							Annotation{Key: eventSpanNameAnnotationKey},
 						},
 					},
 					Sub: []*Trace{
@@ -149,9 +141,7 @@ func TestInfluxDBStore(t *testing.T) {
 								ID: SpanID{Trace: 1, Span: 111, Parent: 11},
 								Annotations: Annotations{
 									Annotation{Key: "Name", Value: []byte("localhost:8699/sub1")},
-									Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
-									Annotation{Key: clientEventKey, Value: []byte("")},
-									Annotation{Key: serverEventKey, Value: []byte("")},
+									Annotation{Key: eventSpanNameAnnotationKey},
 								},
 							},
 							Sub: []*Trace{
@@ -160,9 +150,7 @@ func TestInfluxDBStore(t *testing.T) {
 										ID: SpanID{Trace: 1, Span: 1111, Parent: 111},
 										Annotations: Annotations{
 											Annotation{Key: "Name", Value: []byte("localhost:8699/sub2")},
-											Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
-											Annotation{Key: clientEventKey, Value: []byte("")},
-											Annotation{Key: serverEventKey, Value: []byte("")},
+											Annotation{Key: eventSpanNameAnnotationKey},
 										},
 									},
 								},
@@ -177,9 +165,7 @@ func TestInfluxDBStore(t *testing.T) {
 				ID: SpanID{2, 200, 0},
 				Annotations: Annotations{
 					Annotation{Key: "Name", Value: []byte("/")},
-					Annotation{Key: "Server.Request.Method", Value: []byte("GET")},
-					Annotation{Key: clientEventKey, Value: []byte("")},
-					Annotation{Key: serverEventKey, Value: []byte("")},
+					Annotation{Key: eventSpanNameAnnotationKey},
 				},
 			},
 		},


### PR DESCRIPTION
#### Details

Issue: #117 

- [x] tl;dr - Improves how we reassemble InfluxDB fields to span annotations:
  - Updates `func annotationsFromRow(...)` to include common logic that we use to reassemble data back from InfluxDB fields to span `annotations`. Now it uses `func annotationsFromEvents(..)` which will discard those annotations that should no be included because were not explicitly save by `Collect(...)` but that are present because `InfluxDB` will return all the fields present on `spans` measurement:
    - Eg. A field named `Client.Request.Method` might contain values for sub-spans but not for root-spans. Since span annotations are non-deterministic, current strategy for query those annotations(fields) is to do `select * from spans ....`, therefore: `Client.Request.Method` will be included in the query result even for root-spans:
![screen shot 2016-03-17 at 14 18 14](https://cloud.githubusercontent.com/assets/1000404/13858540/1eb5c054-ec4d-11e5-8d08-cc9715b0c54c.png)

