### PR TITLE
Improvements on `addChildren`.

### DIFF
--- a/influxdb_store.go
+++ b/influxdb_store.go
@@ -646,7 +646,14 @@ func addChildren(root *Trace, children []*Trace) error {
 		if len(children) == 0 {
 			break
 		}
-		if try == retries { // At this point all children were added to their parent.
+
+		// At this point, all children were added to their parent spans. Any children
+		// left over in the children slice do not have parents. This could happen if,
+		// for example, a parent service fails to record its span information to the
+		// collection server but its downstream services do send their span information
+		// properly. In this case, we gracefully degrade by adding these orphan spans to
+		// the root span.
+		if try == retries {
 
 			// Iterates over children(without parent found on `root`) and appends them as sub-traces to `root`.
 			for _, child := range children {

--- a/influxdb_store.go
+++ b/influxdb_store.go
@@ -620,10 +620,9 @@ func schemasFromAnnotations(anns []Annotation) string {
 // addChildren adds `children` to `root`; each child is appended to it's trace parent.
 func addChildren(root *Trace, children []*Trace) error {
 	var (
-		addFn         func() // Handles children appending to it's trace parent.
-		errMaxRetries error  = errors.New("maximum number of retries")
-		retries       int    = len(children) // Maximum number of retries to add `children` elements to `root`.
-		try           int                    // Current number of try to add `children` elements to `root`.
+		addFn   func()                 // Handles children appending to it's trace parent.
+		retries int    = len(children) // Maximum number of retries to add `children` elements to `root`.
+		try     int                    // Current number of try to add `children` elements to `root`.
 	)
 	addFn = func() {
 		for i := len(children) - 1; i >= 0; i-- {
@@ -647,8 +646,15 @@ func addChildren(root *Trace, children []*Trace) error {
 		if len(children) == 0 {
 			break
 		}
-		if try == retries {
-			return errMaxRetries
+		if try == retries { // At this point all children were added to their parent.
+
+			// Iterates over children(without parent found on `root`) and appends them as sub-traces to `root`.
+			for _, child := range children {
+				if child.ID.Trace == root.ID.Trace {
+					root.Sub = append(root.Sub, child)
+				}
+			}
+			return nil
 		}
 		addFn()
 		try++

--- a/influxdb_store_test.go
+++ b/influxdb_store_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 const (
+	clientEventKey             string = schemaPrefix + clientEventSchema
+	clientEventSchema          string = "HTTPClient"
+	serverEventKey             string = schemaPrefix + serverEventSchema
+	serverEventSchema          string = "HTTPServer"
 	eventSpanNameAnnotationKey string = schemaPrefix + "name"
 )
 

--- a/influxdb_store_test.go
+++ b/influxdb_store_test.go
@@ -17,6 +17,73 @@ const (
 	eventSpanNameAnnotationKey string = schemaPrefix + "name"
 )
 
+func TestAddChildren(t *testing.T) {
+	root := &Trace{Span: Span{ID: SpanID{1, 100, 0}}}
+	want := &Trace{
+		Span: root.Span,
+		Sub: []*Trace{
+			&Trace{
+				Span: Span{ID: SpanID{1, 101, 100}},
+				Sub: []*Trace{
+					&Trace{
+						Span: Span{ID: SpanID{1, 1011, 101}},
+						Sub: []*Trace{
+							&Trace{
+								Span: Span{ID: SpanID{1, 10111, 1011}},
+							},
+							&Trace{
+								Span: Span{ID: SpanID{1, 10112, 1011}},
+							},
+						},
+					},
+					&Trace{
+						Span: Span{ID: SpanID{1, 1012, 101}},
+					},
+				},
+			},
+			&Trace{
+				Span: Span{ID: SpanID{1, 102, 100}},
+				Sub: []*Trace{
+					&Trace{
+						Span: Span{ID: SpanID{1, 1021, 102}},
+						Sub: []*Trace{
+							&Trace{
+								Span: Span{ID: SpanID{1, 10211, 1021}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	var (
+		children      []*Trace
+		sortSubTraces func(root *Trace)
+		subTraces     func(root *Trace, traces []*Trace) []*Trace
+	)
+	subTraces = func(root *Trace, traces []*Trace) []*Trace {
+		traces = append(traces, root.Sub...)
+		for _, sub := range root.Sub {
+			subTraces(sub, traces)
+		}
+		return traces
+	}
+	sortSubTraces = func(root *Trace) {
+		sort.Sort(tracesByIDSpan(root.Sub))
+		for _, sub := range root.Sub {
+			sortSubTraces(sub)
+		}
+	}
+	if err := addChildren(root, subTraces(want, children)); err != nil {
+		t.Fatal(err)
+	}
+	sortSubTraces(root)
+	sortSubTraces(want)
+	if !reflect.DeepEqual(root, want) {
+		t.Fatalf("got: %v, want: %v", root, want)
+	}
+}
+
 func TestMergeSchemasField(t *testing.T) {
 	cases := []struct {
 		NewField string


### PR DESCRIPTION
#### Details
Issue: #118
Built on top of: #124

- [x] Adds tests for `addChildren`.
- [x] Updates `addChildren`:
  - Adds fallback for sub-traces which their parent was not found on trace root, so those sub-traces are added now to the trace root.