### PR TITLE
Improvements on `Recorder`.

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -32,6 +32,7 @@ func TestAggregateStore(t *testing.T) {
 			E: time.Now(),
 		}
 		rec.Event(e)
+		rec.Finish()
 		if errs := rec.Errors(); len(errs) > 0 {
 			t.Fatal(errs)
 		}
@@ -103,6 +104,7 @@ func TestAggregateStoreNSlowest(t *testing.T) {
 				E: now.Add(times[i]),
 			}
 			rec.Event(e)
+			rec.Finish()
 			if errs := rec.Errors(); len(errs) > 0 {
 				t.Fatal(errs)
 			}
@@ -218,6 +220,7 @@ func TestAggregateStoreMinEvictAge(t *testing.T) {
 			E: time.Now(),
 		}
 		rec.Event(e)
+		rec.Finish()
 		if errs := rec.Errors(); len(errs) > 0 {
 			t.Fatal(errs)
 		}
@@ -238,6 +241,7 @@ func TestAggregateStoreMinEvictAge(t *testing.T) {
 	// Trigger the eviction by making any sort of collection.
 	rec := NewRecorder(NewRootSpanID(), as)
 	rec.Name("collect")
+	rec.Finish()
 	if errs := rec.Errors(); len(errs) > 0 {
 		t.Fatal(errs)
 	}

--- a/httptrace/client.go
+++ b/httptrace/client.go
@@ -158,6 +158,7 @@ func (t *Transport) RoundTrip(original *http.Request) (*http.Response, error) {
 		e.Response.StatusCode = -1
 	}
 	child.Event(e)
+	child.Finish()
 	return resp, err
 }
 

--- a/httptrace/server.go
+++ b/httptrace/server.go
@@ -103,6 +103,7 @@ func Middleware(c appdash.Collector, conf *MiddlewareConfig) func(rw http.Respon
 			rec.Name(r.URL.Host + r.URL.Path)
 		}
 		rec.Event(e)
+		rec.Finish()
 	}
 }
 


### PR DESCRIPTION
#### Details

Related issue: https://github.com/sourcegraph/appdash/issues/132

- Adds `Recorder.Finish(...)` method, such that a span will only be recorded to once (a recorder produces only one `Store.Collect(...)` call for a given `SpanID`).
- Updates httptrace client & server to call `Recorder.Finish(...)` in order to collect the span.
- Fixes recorder tests.