### PR TITLE
Perf. improvements for InfluxDBStore.

### DIFF
--- a/httptrace/client.go
+++ b/httptrace/client.go
@@ -140,7 +140,7 @@ func (t *Transport) RoundTrip(original *http.Request) (*http.Response, error) {
 
 	child := t.Recorder.Child()
 	if t.SetName {
-		child.Name(req.URL.Host + req.URL.Path)
+		child.Name("Request " + req.URL.Host + req.URL.Path)
 	}
 
 	// New child span is created and set as HTTP header instead of using `child`

--- a/httptrace/client.go
+++ b/httptrace/client.go
@@ -142,7 +142,12 @@ func (t *Transport) RoundTrip(original *http.Request) (*http.Response, error) {
 	if t.SetName {
 		child.Name(req.URL.Host + req.URL.Path)
 	}
-	SetSpanIDHeader(req.Header, child.SpanID)
+
+	// New child span is created and set as HTTP header instead of using `child`
+	// in order to have a single span recording operation per httptrace event(HTTPClient or HTTPServer).
+	span := appdash.NewSpanID(t.Recorder.SpanID)
+
+	SetSpanIDHeader(req.Header, span)
 
 	e := NewClientEvent(req)
 	e.ClientSend = time.Now()

--- a/httptrace/client.go
+++ b/httptrace/client.go
@@ -144,7 +144,8 @@ func (t *Transport) RoundTrip(original *http.Request) (*http.Response, error) {
 	}
 
 	// New child span is created and set as HTTP header instead of using `child`
-	// in order to have a single span recording operation per httptrace event(HTTPClient or HTTPServer).
+	// in order to have a single span recording operation per httptrace event
+	// (HTTPClient or HTTPServer).
 	span := appdash.NewSpanID(t.Recorder.SpanID)
 
 	SetSpanIDHeader(req.Header, span)

--- a/httptrace/server.go
+++ b/httptrace/server.go
@@ -98,9 +98,9 @@ func Middleware(c appdash.Collector, conf *MiddlewareConfig) func(rw http.Respon
 
 		rec := appdash.NewRecorder(*spanID, c)
 		if e.Route != "" {
-			rec.Name(e.Route)
+			rec.Name("Serve " + e.Route)
 		} else {
-			rec.Name(r.URL.Host + r.URL.Path)
+			rec.Name("Serve " + r.URL.Host + r.URL.Path)
 		}
 		rec.Event(e)
 		rec.Finish()

--- a/influxdb_store_test.go
+++ b/influxdb_store_test.go
@@ -76,31 +76,6 @@ func TestAddChildren(t *testing.T) {
 	}
 }
 
-func TestMergeSchemasField(t *testing.T) {
-	cases := []struct {
-		NewField string
-		OldField string
-		Want     string
-	}{
-		{NewField: "", OldField: "", Want: ""},
-		{NewField: "HTTPClient", OldField: "", Want: "HTTPClient"},
-		{NewField: "", OldField: "name", Want: "name"},
-		{NewField: "HTTPClient", OldField: "name", Want: "HTTPClient,name"},
-		{NewField: "HTTPServer", OldField: "HTTPClient,name", Want: "HTTPServer,HTTPClient,name"},
-	}
-	for i, c := range cases {
-		got, err := mergeSchemasField(c.NewField, c.OldField)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		got = sortSchemas(got)
-		want := sortSchemas(c.Want)
-		if got != want {
-			t.Fatalf("case #%d - got: %v, want: %v", i, got, c.Want)
-		}
-	}
-}
-
 func TestSchemasFromAnnotations(t *testing.T) {
 	anns := []Annotation{
 		Annotation{Key: schemaPrefix + "HTTPClient"},


### PR DESCRIPTION
#### Details

- Issue: #132 

- [x] Updates `httptrace` to allow 1 `span` recording operation per event(HTTPClient, HTTPServer), meaning now there is a one span per HTTPClient or HTTPServer, before HTTPClient & HTTPServer was joined in a single span.
- [x] Removes span look-up within `InfluxDBStore.Collect(...)` & related code:
  - Not required anymore since the `httptrace` changed mentioned above; enables to have a single `InfluxDBStore.Collect(...)` call per `Recorder.Finish(..,)` call.