### PR TITLE
opentracing: No longer record unsampled spans

### DIFF
--- a/opentracing/recorder.go
+++ b/opentracing/recorder.go
@@ -41,6 +41,10 @@ func NewRecorder(collector appdash.Collector, opts Options) *Recorder {
 // RecordSpan converts a RawSpan into the Appdash representation of a span
 // and records it to the underlying collector.
 func (r *Recorder) RecordSpan(sp basictracer.RawSpan) {
+	if !sp.Sampled {
+		return
+	}
+
 	spanID := appdash.SpanID{
 		Span:   appdash.ID(uint64(sp.SpanID)),
 		Trace:  appdash.ID(uint64(sp.TraceID)),

--- a/opentracing/recorder_test.go
+++ b/opentracing/recorder_test.go
@@ -29,6 +29,7 @@ func TestOpentracingRecorder(t *testing.T) {
 			TraceID:      1,
 			SpanID:       2,
 			ParentSpanID: 3,
+			Sampled:      true,
 		},
 		Tags: map[string]interface{}{
 			"tag": 1,
@@ -40,7 +41,17 @@ func TestOpentracingRecorder(t *testing.T) {
 		Duration:  time.Duration(1),
 	}
 
+	unsampledRaw := basictracer.RawSpan{
+		Context: basictracer.Context{
+			TraceID:      1,
+			SpanID:       2,
+			ParentSpanID: 3,
+			Sampled:      false,
+		},
+	}
+
 	r.RecordSpan(raw)
+	r.RecordSpan(unsampledRaw)
 
 	tsAnnotations := marshalEvent(appdash.Timespan{raw.Start, raw.Start.Add(raw.Duration)})
 	want := []*wire.CollectPacket{


### PR DESCRIPTION
The opentracing recorder was recording all spans regardless of their sampling status. 