### PR TITLE
InfluxDBStore: fix index out of bounds panic on Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - [#153](https://github.com/sourcegraph/appdash/pull/153) Added a Recorder.Logger field which, when non-nil, causes errors to be logged instead of checked explicitly via the Errors method.
   - [#154](https://github.com/sourcegraph/appdash/pull/154) Added trace permalinks which encode the trace within the URL.
   - [#155](https://github.com/sourcegraph/appdash/pull/155) Cleaned up InfluxDBStore configuration by adding sane defaults.
+  - [#156](https://github.com/sourcegraph/appdash/pull/156) Fixed an index out of bounds panic on the Dashboard.
 - Apr 15, 2016 - **Breaking Changes!**
   - [#136](https://github.com/sourcegraph/appdash/pull/136) Users must now call `Recorder.Finish` when finished recording, or else data    will not be collected.
   - [#136](https://github.com/sourcegraph/appdash/pull/136) AggregateStore is removed in favor of InfluxDBStore, which is also embeddable, and is generally faster and more reliable. Refer to the [cmd/webapp-influxdb](https://github.com/sourcegraph/appdash/blob/master/examples/cmd/webapp-influxdb/main.go#L50) for further information on how to migrate to `InfluxDBStore`, or [read more about why this change was made](https://github.com/sourcegraph/appdash/issues/137).

--- a/influxdb_store.go
+++ b/influxdb_store.go
@@ -266,7 +266,7 @@ func (in *InfluxDBStore) Aggregate(start, end time.Duration) ([]*AggregatedResul
 					if err != nil {
 						panic(err) // never happens, just for sanity.
 					}
-					results[i].Slowest = append(results[i].Slowest, id)
+					results[rowIndex].Slowest = append(results[rowIndex].Slowest, id)
 				}
 			}
 		}


### PR DESCRIPTION
- Introduced by `094b22`
- `i` was renamed to `rowIndex` in that commit, but `results[i].Slowest = append(results[i].Slowest, id)`
  was not updated to reflect this.

Confirmed fix by visiting the Dashboard page (no more panic).

Based on #155 for simplicity.