### PR TITLE
InfluxDBStore: use Continuous Queries to make the Dashboard very responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - [#156](https://github.com/sourcegraph/appdash/pull/156) Fixed an index out of bounds panic on the Dashboard.
   - [#157](https://github.com/sourcegraph/appdash/pull/157) Added proper point-batching support to InfluxDBStore.
   - [#157](https://github.com/sourcegraph/appdash/pull/157) Changed `ChunkedCollector.FlushTimeout` default from 50ms to 2s.
+  - [#158](https://github.com/sourcegraph/appdash/pull/158) Made InfluxDBStore use Continuous Queries so the Dashboard is very responsive.
 - Apr 15, 2016 - **Breaking Changes!**
   - [#136](https://github.com/sourcegraph/appdash/pull/136) Users must now call `Recorder.Finish` when finished recording, or else data    will not be collected.
   - [#136](https://github.com/sourcegraph/appdash/pull/136) AggregateStore is removed in favor of InfluxDBStore, which is also embeddable, and is generally faster and more reliable. Refer to the [cmd/webapp-influxdb](https://github.com/sourcegraph/appdash/blob/master/examples/cmd/webapp-influxdb/main.go#L50) for further information on how to migrate to `InfluxDBStore`, or [read more about why this change was made](https://github.com/sourcegraph/appdash/issues/137).


### PR DESCRIPTION
This change uses Continuous Queries to downsample our span data in such a way as to make the Dashboard page very responsive even when there are a large number of spans being stored.

Fixes #141

Based on #157 for simplicity.