### PR TITLE
InfluxDBStore: do not use deprecated "IF NOT EXISTS" condition when creating DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - [#157](https://github.com/sourcegraph/appdash/pull/157) Added proper point-batching support to InfluxDBStore.
   - [#157](https://github.com/sourcegraph/appdash/pull/157) Changed `ChunkedCollector.FlushTimeout` default from 50ms to 2s.
   - [#158](https://github.com/sourcegraph/appdash/pull/158) Made InfluxDBStore use Continuous Queries so the Dashboard is very responsive.
+  - [#159](https://github.com/sourcegraph/appdash/pull/159) InfluxDBStore no longer uses the deprecated `IF NOT EXISTS` condition when creating the DB.
 - Apr 15, 2016 - **Breaking Changes!**
   - [#136](https://github.com/sourcegraph/appdash/pull/136) Users must now call `Recorder.Finish` when finished recording, or else data    will not be collected.
   - [#136](https://github.com/sourcegraph/appdash/pull/136) AggregateStore is removed in favor of InfluxDBStore, which is also embeddable, and is generally faster and more reliable. Refer to the [cmd/webapp-influxdb](https://github.com/sourcegraph/appdash/blob/master/examples/cmd/webapp-influxdb/main.go#L50) for further information on how to migrate to `InfluxDBStore`, or [read more about why this change was made](https://github.com/sourcegraph/appdash/issues/137).

--- a/influxdb_store.go
+++ b/influxdb_store.go
@@ -456,7 +456,7 @@ func (in *InfluxDBStore) Close() error {
 }
 
 func (in *InfluxDBStore) createDBIfNotExists() error {
-	q := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", in.dbName)
+	q := fmt.Sprintf("CREATE DATABASE %s", in.dbName)
 
 	// If a default retention policy is provided, it's used to extend the query in order to create the database with
 	// a default retention policy.


### PR DESCRIPTION
`IF NOT EXIST` is the default and only behavior (see [InfluxDB issue here](https://github.com/influxdata/influxdb/issues/5707)), confirmed working locally.

Based on #158 for simplicity.