### PR TITLE
traceapp/tmpl/data: do not use {{.BaseURL}}{{.Permalink}}

### DIFF
--- a/traceapp/tmpl/data/trace.html
+++ b/traceapp/tmpl/data/trace.html
@@ -16,7 +16,7 @@
     <span style="font-size: 12px; vertical-align: middle;">
       (
       <span id="copy-permalink-clip">
-        <a id="copy-permalink" data-clipboard-text="{{.BaseURL}}{{.Permalink}}" href="{{.BaseURL}}{{.Permalink}}">Permalink</a>
+        <a id="copy-permalink" data-clipboard-text="{{.Permalink}}" href="{{.Permalink}}">Permalink</a>
       </span>
       |
       <span id="copy-json-clip"><a id="copy-json" data-clipboard-text="{{.JSONTrace}}">Export as JSON</a></span>


### PR DESCRIPTION
Because {{.Permalink}} is already inclusive of the base URL that is given
as the base router parameter to `NewRouter`.

This fixes an issue with the trace permalinks where they were incorectly `//traces/<id>`
instead of `http://mysite.com/traces/<id>` for example.

Tested manually / locally.