### PR TITLE
Add OpenTracing Python implementation

### DIFF
--- a/python/appdash/__init__.py
+++ b/python/appdash/__init__.py
@@ -1,2 +1,3 @@
 from spanid import *
 from event import *
+from recorder import *

--- a/python/appdash/event.py
+++ b/python/appdash/event.py
@@ -73,7 +73,7 @@ class TimespanEvent:
         self.start = timeString(start)
         self.end = timeString(end)
 
-    def marshal(self)
+    def marshal(self):
         return {"Span.Start": self.start, "Span.End": self.end}
 
 # SQLEvent is an SQL query event with send and receive times, as well as the

--- a/python/appdash/event.py
+++ b/python/appdash/event.py
@@ -63,6 +63,19 @@ class LogEvent:
     def marshal(self):
         return {"Msg": self.msg, "Time": self.time}
 
+class TimespanEvent:
+
+    schema = "Timespan"
+    start = ""
+    end = ""
+
+    def __init__(self, start, end):
+        self.start = timeString(start)
+        self.end = timeString(end)
+
+    def marshal(self)
+        return {"Span.Start": self.start, "Span.End": self.end}
+
 # SQLEvent is an SQL query event with send and receive times, as well as the
 # actual SQL that was ran, and a optional tag.
 class SQLEvent:
@@ -71,7 +84,7 @@ class SQLEvent:
     # sql is literally the SQL query that was ran.
     sql = ""
 
-    # tag is a optional user-created tag associated with the SQL event. 
+    # tag is a optional user-created tag associated with the SQL event.
     tag = ""
 
     # RFC3339-UTC timestamp of when the query was sent, and later a result received.

--- a/python/appdash/recorder.py
+++ b/python/appdash/recorder.py
@@ -1,0 +1,37 @@
+from spanid import SpanID, Annotation
+
+class AppdashRecorder(object):
+    def __init__(self, collector):
+        self._collector = collector
+
+    def record_span(self, span):
+        if not span.context.sampled:
+            return
+        annotations = []
+        span_id = SpanID()
+        span_id.trace = span.context.trace_id
+        span_id.span = span.context.span
+        span_id.parent = span.context.parent_span_id
+
+        # It might not be right to build a list, maybe send events one at a time.
+        annotations.append(MarshalEvent(SpanNameEvent(span.operation_name)))
+
+        approx_endtime = span.context.start_time + span.duration
+        annotations.append(MarshalEvent(
+            TimespanEvent(span.context.start_time, approx_endtime)))
+
+        for key in span.tags:
+            annotations.append(Annotation(key, span.tag[key])
+
+        for key in span.context.baggage_items:
+            annotations.append(Annotation(key, span.contex.baggage_items[value])
+
+        self._collector.collect(span_id, events)
+
+
+class AppdashTracer(BasicTracer):
+
+    def __init__(self, collector, sampler=None):
+        self._recorder = AppdashRecorder(collector)
+        super(AppdashTracer, self).__init__(recorder=self._recorder,
+                                            sampler=sampler)

--- a/python/appdash/recorder.py
+++ b/python/appdash/recorder.py
@@ -23,7 +23,6 @@ class AppdashRecorder(SpanRecorder):
         if span.context.parent_id is not None:
             span_id.parent = span.context.parent_id
 
-        # It might not be right to build a list, maybe send events one at a time.
         self._collector.collect(span_id,
                 *event.MarshalEvent(event.SpanNameEvent(span.operation_name)))
 

--- a/python/example_opentracing_socket.py
+++ b/python/example_opentracing_socket.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+# Imports
+import time
+import appdash
+
+# Appdash: Socket Collector
+from appdash.sockcollector import RemoteCollector
+
+# Create a remote appdash collector.
+collector = RemoteCollector(debug=True)
+collector.connect(host="localhost", port=7701)
+
+# Create a tracer
+tracer = appdash.create_new_tracer(collector)
+
+for i in range(0, 7):
+    # Generate a few spans with some annotations.
+    span = None
+    # Name the span.
+    if i == 0:
+        span = tracer.start_span("Request")
+    else:
+        span = tracer.start_span("SQL Query")
+
+    span.set_tag("query", "SELECT * FROM table_name;")
+    span.set_tag("foo", "bar")
+
+    if i % 2 == 0:
+        span.log_event("Hello world!")
+
+    child_span = tracer.start_span("child", parent=span)
+    child_span.finish()
+
+    span.finish(finish_time=time.time()+2)
+
+# Close the collector's connection.
+collector.close()

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,4 +10,5 @@ setup(
     author_email = 'hi@sourcegraph.com',
     url = 'https://sourcegraph.com/sourcegraph/appdash',
     packages = ['appdash'],
+    install_requires = ['basictracer'],
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-# from distutils.core import setup
 from setuptools import setup
 
 setup(

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+# from distutils.core import setup
+from setuptools import setup
 
 setup(
     name = 'Appdash',


### PR DESCRIPTION
Now that https://github.com/opentracing/basictracer-python is a thing, I've added a python opentracing implementation for Python. What's really cool about this is that it's 100% compatible with the Golang implementation, so two processes can send each other spans and join traces using the inject/join methods.

I'm not too sure how python dependencies work(I'm not too great with python), but I changed setup.py to use setuptools to bring in the basictracer dependency. 
