### PR TITLE
Replace gorilla/context with stdlib context

### DIFF
--- a/httptrace/server.go
+++ b/httptrace/server.go
@@ -74,7 +74,7 @@ func Middleware(c appdash.Collector, conf *MiddlewareConfig) func(rw http.Respon
 		usingProvidedSpanID := (spanFromHeader == HeaderSpanID)
 
 		if conf.SetContextSpan != nil {
-			conf.SetContextSpan(r, *spanID)
+			r = conf.SetContextSpan(r, *spanID)
 		}
 
 		e := NewServerEvent(r)
@@ -121,7 +121,7 @@ type MiddlewareConfig struct {
 	// either taken from the client request header or created anew) in
 	// the HTTP request context, so it may be used by other parts of
 	// the handling process.
-	SetContextSpan func(*http.Request, appdash.SpanID)
+	SetContextSpan func(*http.Request, appdash.SpanID) *http.Request
 }
 
 // responseInfoRecorder is an http.ResponseWriter that records a

--- a/httptrace/server_test.go
+++ b/httptrace/server_test.go
@@ -76,7 +76,7 @@ func TestMiddleware_useSpanFromHeaders(t *testing.T) {
 	mw := Middleware(c, &MiddlewareConfig{
 		RouteName:      func(r *http.Request) string { return "r" },
 		CurrentUser:    func(r *http.Request) string { return "u" },
-		SetContextSpan: func(r *http.Request, id appdash.SpanID) { setContextSpan = id },
+		SetContextSpan: func(r *http.Request, id appdash.SpanID) *http.Request { setContextSpan = id; return r },
 	})
 
 	w := httptest.NewRecorder()
@@ -128,7 +128,7 @@ func TestMiddleware_createNewSpan(t *testing.T) {
 
 	var setContextSpan appdash.SpanID
 	mw := Middleware(c, &MiddlewareConfig{
-		SetContextSpan: func(r *http.Request, id appdash.SpanID) { setContextSpan = id },
+		SetContextSpan: func(r *http.Request, id appdash.SpanID) *http.Request { setContextSpan = id; return r },
 	})
 
 	w := httptest.NewRecorder()


### PR DESCRIPTION
This PR changes the httptrace API by requiring `*http.Request` to be returned from `SetContextSpan`. To avoid breaking ani API,this change can be avoided by overwriting the fields of the request structure directly, dereferencing the shallow clone returned by `WithContext`.
