### PR TITLE
Fixes compatibility with basictracer's SpanContext

### DIFF
--- a/python/appdash/recorder.py
+++ b/python/appdash/recorder.py
@@ -20,8 +20,8 @@ class AppdashRecorder(SpanRecorder):
         span_id = SpanID()
         span_id.trace = span.context.trace_id
         span_id.span = span.context.span_id
-        if span.context.parent_id is not None:
-            span_id.parent = span.context.parent_id
+        if span.parent_id is not None:
+            span_id.parent = span.parent_id
 
         self._collector.collect(span_id,
                 *event.MarshalEvent(event.SpanNameEvent(span.operation_name)))


### PR DESCRIPTION
opentracing/basictracer-python removed Context.parent_id
https://github.com/opentracing/basictracer-python/commit/343ee8effc770afd1c69445bc8753107f48de51d
this patch gets the parent_id from basictracer's Span
