### PR TITLE
README: Remove reference to govendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ distribution. This means that if you want to modify the template data in `tracea
 
 After you're finished making changes to the templates, always run `go generate sourcegraph.com/sourcegraph/appdash/traceapp/tmpl` so that the `data_vfsdata.go` file is updated for normal Appdash users that aren't interested in modifying the template data.
 
-Dependencies are vendored using [govendor](https://github.com/kardianos/govendor). Prior to updating InfluxDB dependencies [you should run gdm restore in that repository](https://github.com/influxdata/influxdb/blob/master/CONTRIBUTING.md#build-and-test).
-
 ## Components
 
 Appdash follows the design and naming conventions of


### PR DESCRIPTION
External dependencies are not being managed using govendor or any
vendoring tool. The README is out of date and refers to previous
development workflow which included vendoring external dependencies.

Update the README to reflect the current state of the project and
remove references to govendor.