### PR TITLE
travis: Go 1.7+ is the minimum supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false
 language: go
 go:
- - 1.6
+ - 1.7
  - tip
 
 matrix:


### PR DESCRIPTION
Appdash can no longer be built using Go 1.6 with implicit external
dependencies. One or more upstream dependencies imports the "context"
package from the Go 1.7 standard library which means Appdash must use
Go 1.7 in order to build it. Using Go 1.6 causes the following build
error when using Travis CI:

    package context: unrecognized import path "context"

Resolve the issue by updating the Travis CI build configuration to
use Go 1.7 as the minimum supported Go version.