### PR TITLE
FIX start_span(): basictracer-python was updated

### DIFF
--- a/python/example_opentracing_socket.py
+++ b/python/example_opentracing_socket.py
@@ -29,7 +29,7 @@ for i in range(0, 7):
     if i % 2 == 0:
         span.log_event("Hello world!")
 
-    child_span = tracer.start_span("child", parent=span)
+    child_span = tracer.start_span("child", child_of=span)
     child_span.finish()
 
     span.finish(finish_time=time.time()+2)


### PR DESCRIPTION
Actual version of basictracer-python seems to had replaced
``parent`` by ``child_of``, as seen in:
https://github.com/opentracing/basictracer-python/blob/eaf86dc/basictracer/tracer.py#L50