### PR TITLE
Change negroni repo link

### DIFF
--- a/examples/cmd/webapp-opentracing/main.go
+++ b/examples/cmd/webapp-opentracing/main.go
@@ -18,7 +18,7 @@ import (
 	appdashtracer "sourcegraph.com/sourcegraph/appdash/opentracing"
 	"sourcegraph.com/sourcegraph/appdash/traceapp"
 
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/gorilla/mux"
 	opentracing "github.com/opentracing/opentracing-go"
 )

--- a/examples/cmd/webapp/main.go
+++ b/examples/cmd/webapp/main.go
@@ -16,7 +16,7 @@ import (
 	"sourcegraph.com/sourcegraph/appdash/httptrace"
 	"sourcegraph.com/sourcegraph/appdash/traceapp"
 
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
 )


### PR DESCRIPTION
From negroni's Readme

**Notice**: This is the library formerly known as github.com/codegangsta/negroni -- Github will     
automatically redirect requests to this repository, but we recommend updating your references for clarity.