### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/appdash/serve_cmd.go
+++ b/cmd/appdash/serve_cmd.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -130,11 +129,11 @@ func (c *ServeCmd) Execute(args []string) error {
 	var l net.Listener
 	var proto string
 	if c.TLSCert != "" || c.TLSKey != "" {
-		certBytes, err := ioutil.ReadFile(c.TLSCert)
+		certBytes, err := os.ReadFile(c.TLSCert)
 		if err != nil {
 			log.Fatal(err)
 		}
-		keyBytes, err := ioutil.ReadFile(c.TLSKey)
+		keyBytes, err := os.ReadFile(c.TLSKey)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/wire/collector.pb.go
+++ b/internal/wire/collector.pb.go
@@ -13,9 +13,13 @@ It has these top-level messages:
 */
 package wire
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
+
+	proto "github.com/gogo/protobuf/proto"
+
+	math "math"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/store.go
+++ b/store.go
@@ -4,7 +4,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -360,7 +359,7 @@ func PersistEvery(s PersistentStore, interval time.Duration, file string) error 
 	for {
 		time.Sleep(interval)
 
-		f, err := ioutil.TempFile("", "appdash")
+		f, err := os.CreateTemp("", "appdash")
 		if err != nil {
 			return err
 		}

--- a/store_test.go
+++ b/store_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"reflect"
@@ -496,7 +495,7 @@ func BenchmarkMemoryStoreWrite1000(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		err := ms.Write(ioutil.Discard)
+		err := ms.Write(io.Discard)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/traceapp/app.go
+++ b/traceapp/app.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	htmpl "html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -295,7 +294,7 @@ func (a *App) serveAggregate(w http.ResponseWriter, r *http.Request) error {
 func (a *App) serveTraceUpload(w http.ResponseWriter, r *http.Request) error {
 	// Read the uploaded JSON trace data.
 	defer r.Body.Close()
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/traceapp/tmpl.go
+++ b/traceapp/tmpl.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	htmpl "html/template"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -100,7 +99,7 @@ func (a *App) parseHTMLTemplates(sets [][]string) error {
 			if err != nil {
 				return fmt.Errorf("template %v: %s", set, err)
 			}
-			tmplBytes, err := ioutil.ReadAll(tmplFile)
+			tmplBytes, err := io.ReadAll(tmplFile)
 			tmplFile.Close()
 			if err != nil {
 				return fmt.Errorf("template %v: %s", set, err)


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)