### PR TITLE
Remove image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # appdash (view on [Sourcegraph](https://sourcegraph.com/github.com/sourcegraph/appdash))
 
-<img width=250 src="https://s3-us-west-2.amazonaws.com/sourcegraph-assets/apptrace-screenshot0.png" align="right">
 
 Appdash is an application tracing system for Go, based on
 [Google's Dapper](http://research.google.com/pubs/pub36356.html) and


### PR DESCRIPTION
The image linked to an S3 that was unowned and taken over by a researcher.