### PR TITLE
Revert "Replacing fmt.Sprintf with strconv.Itoa"

### DIFF
--- a/opentracing/json.go
+++ b/opentracing/json.go
@@ -24,7 +24,6 @@ package opentracing
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/opentracing/opentracing-go/log"
 )
@@ -57,23 +56,23 @@ func (ml fieldsAsMap) EmitBool(key string, value bool) {
 }
 
 func (ml fieldsAsMap) EmitInt(key string, value int) {
-	ml[key] = strconv.Itoa(value)
+	ml[key] = fmt.Sprintf("%d", value)
 }
 
 func (ml fieldsAsMap) EmitInt32(key string, value int32) {
-	ml[key] = strconv.Itoa(value)
+	ml[key] = fmt.Sprintf("%d", value)
 }
 
 func (ml fieldsAsMap) EmitInt64(key string, value int64) {
-	ml[key] = strconv.Itoa(value)
+	ml[key] = fmt.Sprintf("%d", value)
 }
 
 func (ml fieldsAsMap) EmitUint32(key string, value uint32) {
-	ml[key] = strconv.Itoa(value)
+	ml[key] = fmt.Sprintf("%d", value)
 }
 
 func (ml fieldsAsMap) EmitUint64(key string, value uint64) {
-	ml[key] = strconv.Itoa(value)
+	ml[key] = fmt.Sprintf("%d", value)
 }
 
 func (ml fieldsAsMap) EmitFloat32(key string, value float32) {


### PR DESCRIPTION
Reverts sourcegraph/appdash#218

Reverting due to https://github.com/sourcegraph/appdash/issues/219.

I have no context on this repo, where it used or who maintains it, and don't know why it doesn't have a CI build check or review process.